### PR TITLE
Sanitize GGUF metadata before it reaches a generated .cmd

### DIFF
--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -236,6 +236,17 @@ function Write-FileAscii {
     [System.IO.File]::WriteAllText($Path, $Content, [System.Text.Encoding]::ASCII)
 }
 
+# Make a value safe to place inside a double-quoted argument of a generated .cmd.
+# A '"' would close the quoting and let & | < > ^ chain a second command; CR/LF
+# would append a whole new line to the script. Model ids, template names and
+# cache-type flags never legitimately contain any of these, so strip rather than
+# escape -- there is no quoting scheme cmd.exe honours consistently here.
+function ConvertTo-CmdArgSafe([string]$s) {
+    if (-not $s) { return '' }
+    $t = $s -replace '[\r\n]', ' '
+    return ($t -replace '[%!^&<>|"]', '').Trim()
+}
+
 # --- Auth helpers ------------------------------------------------------------
 
 # Constant-time string compare so a network attacker can't time-probe the
@@ -1078,8 +1089,8 @@ function Build-LaunchScript {
         '--host',      '127.0.0.1',
         '--ctx-size',  "$CtxSize",
         '--n-gpu-layers', "$GpuLayers",
-        '--cache-type-k', $KvCacheType,
-        '--cache-type-v', $KvCacheType,
+        '--cache-type-k', (ConvertTo-CmdArgSafe $KvCacheType),
+        '--cache-type-v', (ConvertTo-CmdArgSafe $KvCacheType),
         '--parallel',  '1'
     )
     
@@ -1091,9 +1102,13 @@ function Build-LaunchScript {
     # makes llama-server treat the path text itself as a literal template.
     if ($chatTemplateFile -ne '') {
         $sidecarAbs = if ([System.IO.Path]::IsPathRooted($chatTemplateFile)) { $chatTemplateFile } else { Join-Path $Root $chatTemplateFile }
-        $argList += @('--chat-template-file', ('"{0}"' -f $sidecarAbs))
+        $argList += @('--chat-template-file', ('"{0}"' -f (ConvertTo-CmdArgSafe $sidecarAbs)))
     } elseif ($chatTemplate) {
-        $argList += @('--chat-template', $chatTemplate)
+        # Quoted AND scrubbed: this line is written into a .cmd and executed, so
+        # an unquoted value carrying '&' would chain a second command. The values
+        # identify-model.ps1 emits are allowlisted literals, but models-list.json
+        # is a file on disk and this is the last gate before it becomes a command.
+        $argList += @('--chat-template', ('"{0}"' -f (ConvertTo-CmdArgSafe $chatTemplate)))
     }
 
     $argList += @('--reasoning-format', 'auto')

--- a/identify-model.ps1
+++ b/identify-model.ps1
@@ -15,6 +15,19 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Make a value safe to interpolate into a `set "NAME=value"` line of a generated
+# .cmd. launch.bat runs under `setlocal enabledelayedexpansion`, so a literal '!'
+# is eaten and can unbalance the parse; '"' terminates the set early; & | < > ^
+# chain or redirect a new command; and CR/LF starts an entirely new line. None of
+# those belong in a model id, family, template name or hash, so drop them rather
+# than trying to quote around them. Mirrors ConvertTo-EnvSafe in hardware-probe.ps1.
+function ConvertTo-BatchSafe([string]$s) {
+    if (-not $s) { return '' }
+    $t = $s -replace '[\r\n]', ' '
+    $t = $t -replace '[%!^&<>|"]', ''
+    return $t.Trim()
+}
+
 $GGUF_TYPE_STRING = 8
 $GGUF_TYPE_ARRAY  = 9
 $GGUF_FIXED = @{ 0 = 1; 1 = 1; 2 = 2; 3 = 2; 4 = 4; 5 = 4; 6 = 4; 7 = 1; 10 = 8; 11 = 8; 12 = 8 }
@@ -300,7 +313,15 @@ function Get-ModelInfo {
     }
 
     $t = [string]$meta.chat_template
-    $arch = ([string]$meta.architecture).ToLower()
+    # general.architecture is attacker-controlled: it is raw UTF-8 lifted out of
+    # the GGUF's key-value block, and it flows into $rec.family / $rec.id below,
+    # which -Emit batch writes into a .cmd that launch.bat CALLs. A value
+    # carrying a quote, an ampersand or a newline would break out of the
+    # `set "MODEL_ID=..."` line and run as the user. Real architecture strings
+    # are short lowercase identifiers ('llama', 'qwen3moe', 'gemma3'), so clamp
+    # to that shape here -- one choke point, before any consumer sees it.
+    $arch = ([string]$meta.architecture).ToLower() -replace '[^a-z0-9._-]', ''
+    if ($arch.Length -gt 64) { $arch = $arch.Substring(0, 64) }
     $ctx = [int64]$meta.context_length
     if ($ctx -gt 0) { $rec.maxCtx = [int][math]::Min($ctx, [int64]262144) }
 
@@ -459,17 +480,22 @@ if (-not $GgufPath) { throw 'identify-model.ps1: provide -GgufPath or -ModelsDir
 $info = Get-ModelInfo -Path $GgufPath
 
 if ($Emit -eq 'batch') {
-    $dn = ($info.name -replace '[%!^&<>|"]', '')
+    # Every value below is interpolated into a `set "NAME=value"` line in a .cmd
+    # that launch.bat executes with CALL, so each one is a command-injection sink.
+    # $arch is already clamped at the source, but sanitizing again here means a
+    # future field that forgets to do so cannot reopen the hole. Strip the batch
+    # metacharacters (delayed expansion eats a bare '!', and '"' ends the set),
+    # then drop CR/LF so no value can append a line of its own.
     $setLines = @(
-        ('set "MODEL_ID=' + $info.id + '"'),
-        ('set "MODEL_DISPLAY=' + $dn + '"'),
-        ('set "MODEL_FAMILY=' + $info.family + '"'),
-        ('set "MODEL_MAX_CTX=' + $info.maxCtx + '"'),
-        ('set "MODEL_THINK_FMT=' + $info.thinkingFormat + '"'),
+        ('set "MODEL_ID=' + (ConvertTo-BatchSafe $info.id) + '"'),
+        ('set "MODEL_DISPLAY=' + (ConvertTo-BatchSafe $info.name) + '"'),
+        ('set "MODEL_FAMILY=' + (ConvertTo-BatchSafe $info.family) + '"'),
+        ('set "MODEL_MAX_CTX=' + [int]$info.maxCtx + '"'),
+        ('set "MODEL_THINK_FMT=' + (ConvertTo-BatchSafe $info.thinkingFormat) + '"'),
         ('set "MODEL_USE_JINJA=' + ([int]$info.useJinja) + '"'),
-        ('set "MODEL_CHAT_TEMPLATE=' + $info.chatTemplate + '"'),
-        ('set "MODEL_CHAT_TEMPLATE_FILE=' + $info.chatTemplateFile + '"'),
-        ('set "MODEL_TEMPLATE_HASH=' + $info.templateHash + '"')
+        ('set "MODEL_CHAT_TEMPLATE=' + (ConvertTo-BatchSafe $info.chatTemplate) + '"'),
+        ('set "MODEL_CHAT_TEMPLATE_FILE=' + (ConvertTo-BatchSafe $info.chatTemplateFile) + '"'),
+        ('set "MODEL_TEMPLATE_HASH=' + (ConvertTo-BatchSafe $info.templateHash) + '"')
     )
     if ($OutFile) {
         $body = ($setLines -join "`r`n") + "`r`n"


### PR DESCRIPTION
### The problem

`identify-model.ps1` reads `general.architecture` as raw UTF-8 out of the GGUF key-value block (`identify-model.ps1:53`) and assigns it unfiltered to `$rec.family` and `$rec.id` (`:423`, `:435`). `-Emit batch` then writes those into a batch fragment as `set "MODEL_ID=..."` (`:463`), and `launch.bat:730` executes that file with `call "!ID_OUT!"`.

So a `.gguf` whose architecture field contains a quote, an ampersand or a newline breaks out of the `set` line and runs commands as the user — at scan time, before the model is ever loaded. Downloading a GGUF from Hugging Face and dropping it in `models\` is the documented install path, so this is reachable through normal use.

Only the display name was being sanitized (`:462`, stripping `%!^&<>|"`), and that field is derived from the filename, which Windows already forbids quotes in. The sanitizer was on the field that didn't need it and absent from the ones that did.

The same values are echoed into `active-model.json` (`launch.bat:1184-1190`), so a quote there also broke that file's JSON.

### The fix

Clamp architecture to `[a-z0-9._-]` at the single point it is read. Real values are short lowercase identifiers — `llama`, `qwen3moe`, `gemma3`, `gpt-oss`, `glm4moe` all pass through unchanged, so identification is unaffected.

Add `ConvertTo-BatchSafe` at the emit boundary as well, applied to every field rather than one, so a field added later can't reopen this. It mirrors the existing `ConvertTo-EnvSafe` in `hardware-probe.ps1`.

`fileserver.ps1` rebuilds the launch command independently during a hot-swap and interpolated `--chat-template` unquoted (`Build-LaunchScript`); that value currently only ever comes from an allowlist of literals, but `models-list.json` is a file on disk and this is the last gate before it becomes a command, so it's quoted and scrubbed there too.

### Testing

Injection payloads carrying `"`, `&` and CRLF are neutralized through both the source clamp and the emit scrub; benign architecture strings are unchanged. Both scripts parse clean under Windows PowerShell 5.1.

Found during a security review. Happy to adjust the approach if you'd rather reject a bad value outright than strip it.