### PR TITLE
Escape values reaching HTML, inline handlers and CSS in the render path

### DIFF
--- a/js/02-model.js
+++ b/js/02-model.js
@@ -201,7 +201,7 @@ async function loadModelsList() {
 
   if (!IS_SERVED) {
     // Running as file:// — can't fetch. Just show active model name.
-    sel.innerHTML = `<option value="${activeModel.id || 'custom'}">${activeModel.name}</option>`;
+    sel.innerHTML = `<option value="${escapeHtml(activeModel.id || 'custom')}">${escapeHtml(activeModel.name)}</option>`;
     return;
   }
 
@@ -213,7 +213,7 @@ async function loadModelsList() {
     sel.innerHTML = '';
     const models = data.models || [];
     if (models.length === 0) {
-      sel.innerHTML = `<option value="custom">${activeModel.name || 'Unknown'}</option>`;
+      sel.innerHTML = `<option value="custom">${escapeHtml(activeModel.name || 'Unknown')}</option>`;
       return;
     }
 
@@ -239,7 +239,7 @@ async function loadModelsList() {
     if (!_currentModelFile) _currentModelFile = sel.value || null;
   } catch (e) {
     // Fallback — just show what we already know is loaded
-    sel.innerHTML = `<option value="${activeModel.id || 'custom'}">${activeModel.name || 'Model'}</option>`;
+    sel.innerHTML = `<option value="${escapeHtml(activeModel.id || 'custom')}">${escapeHtml(activeModel.name || 'Model')}</option>`;
   }
 }
 

--- a/js/12-render.js
+++ b/js/12-render.js
@@ -80,7 +80,7 @@ function toggleFolderCollapse(id) {
 
 function startFolderRename(id, event) {
   event.stopPropagation(); closePopover();
-  const el = document.querySelector(`[data-folder-id="${id}"] .folder-name-text`);
+  const el = document.querySelector(`[data-folder-id=${CSS.escape(id)}] .folder-name-text`);
   const folder = state.folders.find(f => f.id === id);
   if (!el || !folder) return;
   const input = document.createElement('input');
@@ -142,7 +142,7 @@ function openFolderPicker(threadId, event) {
   const t = state.threads.find(t => t.id === threadId);
   if (!t) return;
   const mkItem = (id, name, active) =>
-    `<button class="pop-item${active?' pop-item-active':''}" onclick="moveThread('${threadId}','${id}')">&#128193; ${escapeHtml(name)}</button>`;
+    `<button class="pop-item${active?' pop-item-active':''}" onclick="moveThread('${escapeJsAttr(threadId)}','${escapeJsAttr(id)}')">&#128193; ${escapeHtml(name)}</button>`;
   let items = mkItem('__none__', 'No folder', !t.folderId);
   if (state.folders.length === 0)
     items += `<div class="pop-hint">No folders yet — click + FOLDER</div>`;
@@ -169,14 +169,14 @@ function openTagEditor(threadId, event) {
 
   const currentHtml = t.tags.length > 0
     ? t.tags.map(tag =>
-        `<span class="tag-pill pop-tag" style="--tc:${getTagColor(tag)}" onclick="removeTag('${threadId}','${tag}')">${escapeHtml(tag)} <span class="tag-x">×</span></span>`
+        `<span class="tag-pill pop-tag" style="--tc:${safeCssColor(getTagColor(tag), 'var(--cyan)')}" onclick="removeTag('${escapeJsAttr(threadId)}','${escapeJsAttr(tag)}')">${escapeHtml(tag)} <span class="tag-x">×</span></span>`
       ).join('')
     : `<span class="pop-empty">none yet</span>`;
 
   const suggestHtml = suggestions.length > 0
     ? `<div class="pop-label">SUGGESTIONS</div><div class="pop-tags-row">${
         suggestions.map(tag =>
-          `<span class="tag-pill pop-tag-sug" style="--tc:${getTagColor(tag)}" onclick="addTag('${threadId}','${tag}')">${escapeHtml(tag)}</span>`
+          `<span class="tag-pill pop-tag-sug" style="--tc:${safeCssColor(getTagColor(tag), 'var(--cyan)')}" onclick="addTag('${escapeJsAttr(threadId)}','${escapeJsAttr(tag)}')">${escapeHtml(tag)}</span>`
         ).join('')
       }</div>`
     : '';
@@ -188,8 +188,8 @@ function openTagEditor(threadId, event) {
       ${suggestHtml}
       <div class="pop-add-row">
         <input class="pop-tag-input" id="pop-tag-input" placeholder="new tag..." maxlength="24"
-               onkeydown="handleTagKey('${threadId}',event)" autocomplete="off">
-        <button class="pop-add-btn" onclick="addTagFromInput('${threadId}')">+</button>
+               onkeydown="handleTagKey('${escapeJsAttr(threadId)}',event)" autocomplete="off">
+        <button class="pop-add-btn" onclick="addTagFromInput('${escapeJsAttr(threadId)}')">+</button>
       </div>
       <div class="pop-hint">Enter to add &nbsp;&middot;&nbsp; type #tag in search to filter</div>
     </div>`);
@@ -235,7 +235,7 @@ function renderThreadItem(t) {
   const isActive = t.id === state.activeThreadId;
   const tagPills = (t.tags && t.tags.length > 0)
     ? `<div class="thread-tags-row">${t.tags.map(tag =>
-        `<span class="tag-pill" style="--tc:${getTagColor(tag)}">${escapeHtml(tag)}</span>`
+        `<span class="tag-pill" style="--tc:${safeCssColor(getTagColor(tag), 'var(--cyan)')}">${escapeHtml(tag)}</span>`
       ).join('')}</div>`
     : '';
   // Pin badge: visible at rest, hidden when controls appear on hover
@@ -248,14 +248,18 @@ function renderThreadItem(t) {
   // Fork count badge (how many branches off THIS thread)
   const forkCount = getAllForksOf(t.id).length;
   const forkBadge = forkCount > 0 ? `<span class="thread-fork-count" title="${forkCount} branch${forkCount > 1 ? 'es' : ''}">⑂${forkCount}</span>` : '';
+  // t.id reaches both an attribute and seven inline handlers. It is normally a
+  // generated base-36 string, but a thread can arrive from a synced peer or an
+  // imported backup, where it is whatever the sender put there.
+  const tid = escapeJsAttr(t.id);
   return `<div class="thread-item${isActive?' active':''}${t.pinned?' thread-pinned':''}"
-       data-thread-id="${t.id}"
+       data-thread-id="${escapeHtml(t.id)}"
        draggable="true"
-       onclick="switchThread('${t.id}')"
-       ondragstart="onThreadDragStart('${t.id}',event)"
-       ondragover="onThreadDragOver('${t.id}',event)"
-       ondragleave="onThreadDragLeave('${t.id}',event)"
-       ondrop="onThreadDrop('${t.id}',event)"
+       onclick="switchThread('${tid}')"
+       ondragstart="onThreadDragStart('${tid}',event)"
+       ondragover="onThreadDragOver('${tid}',event)"
+       ondragleave="onThreadDragLeave('${tid}',event)"
+       ondrop="onThreadDrop('${tid}',event)"
        ondragend="onThreadDragEnd(event)">
     <div class="thread-body">
       <div class="thread-name-row">
@@ -265,11 +269,11 @@ function renderThreadItem(t) {
       ${tagPills}
     </div>
     <div class="thread-ctrl">
-      <button class="thread-ctrl-btn thread-pin-btn${t.pinned?' is-pinned':''}" onclick="togglePin('${t.id}',event)" title="${t.pinned?'Unpin':'Pin'}">&#128204;</button>
-      <button class="thread-ctrl-btn thread-folder-btn" onclick="openFolderPicker('${t.id}',event)" title="Move to folder">&#128193;</button>
-      <button class="thread-ctrl-btn thread-tag-btn" onclick="openTagEditor('${t.id}',event)" title="Tags">&#127991;</button>
-      <button class="thread-ctrl-btn thread-edit-btn" onclick="startRename('${t.id}',event)" title="Rename">&#9998;</button>
-      <button class="thread-ctrl-btn thread-del-btn" onclick="deleteThread('${t.id}',event)" title="Delete">&times;</button>
+      <button class="thread-ctrl-btn thread-pin-btn${t.pinned?' is-pinned':''}" onclick="togglePin('${tid}',event)" title="${t.pinned?'Unpin':'Pin'}">&#128204;</button>
+      <button class="thread-ctrl-btn thread-folder-btn" onclick="openFolderPicker('${tid}',event)" title="Move to folder">&#128193;</button>
+      <button class="thread-ctrl-btn thread-tag-btn" onclick="openTagEditor('${tid}',event)" title="Tags">&#127991;</button>
+      <button class="thread-ctrl-btn thread-edit-btn" onclick="startRename('${tid}',event)" title="Rename">&#9998;</button>
+      <button class="thread-ctrl-btn thread-del-btn" onclick="deleteThread('${tid}',event)" title="Delete">&times;</button>
     </div>
   </div>`;
 }
@@ -307,15 +311,16 @@ function renderSidebar() {
     const totalInFolder = state.threads.filter(t => t.folderId === folder.id).length;
     if (query && fThreads.length === 0) continue;
     const isOpen = !folder.collapsed || !!query;
-    html += `<div class="folder-section${folder.collapsed&&!query?' folder-collapsed':''}" data-folder-id="${folder.id}">
-      <div class="folder-hdr" onclick="toggleFolderCollapse('${folder.id}')" ondragover="onFolderDragOver('${folder.id}',event)" ondragleave="onFolderDragLeave(event)" ondrop="onFolderDrop('${folder.id}',event)">
+    const fid = escapeJsAttr(folder.id);
+    html += `<div class="folder-section${folder.collapsed&&!query?' folder-collapsed':''}" data-folder-id="${escapeHtml(folder.id)}">
+      <div class="folder-hdr" onclick="toggleFolderCollapse('${fid}')" ondragover="onFolderDragOver('${fid}',event)" ondragleave="onFolderDragLeave(event)" ondrop="onFolderDrop('${fid}',event)">
         <span class="folder-chevron">${isOpen?'&#9660;':'&#9658;'}</span>
         <span class="folder-icon">&#128193;</span>
         <span class="folder-name-text">${escapeHtml(folder.name)}</span>
         <span class="folder-count">${totalInFolder}</span>
         <div class="folder-hdr-btns">
-          <button class="folder-btn" onclick="startFolderRename('${folder.id}',event)" title="Rename">&#9998;</button>
-          <button class="folder-btn folder-del" onclick="deleteFolder('${folder.id}',event)" title="Delete">&times;</button>
+          <button class="folder-btn" onclick="startFolderRename('${fid}',event)" title="Rename">&#9998;</button>
+          <button class="folder-btn folder-del" onclick="deleteFolder('${fid}',event)" title="Delete">&times;</button>
         </div>
       </div>
       ${isOpen ? `<div class="folder-threads">${fThreads.length > 0 ? fThreads.map(renderThreadItem).join('') : '<div class="folder-empty">// empty</div>'}</div>` : ''}

--- a/js/13-dashboard.js
+++ b/js/13-dashboard.js
@@ -48,7 +48,7 @@ function renderLandingPage() {
     const desc = (c.personality || c.writingStyle || '').slice(0, 72);
     return `
       <div class="landing-char-card ${isActive ? 'landing-char-active' : ''}"
-           onclick="activateCard('${c.id}')" title="Set as active character">
+           onclick="activateCard('${escapeJsAttr(c.id)}')" title="Set as active character">
         <div class="landing-char-avatar">${avatarHtml}</div>
         <div class="landing-char-info">
           <div class="landing-char-name">${escapeHtml(c.name)}</div>
@@ -78,7 +78,7 @@ function renderLandingPage() {
         : `title="${name}"`;
       return `
         <div class="landing-preset-card ${hasCardData ? 'landing-preset-installable' : ''}" ${clickAttr}>
-          <div class="landing-preset-icon">${icon}</div>
+          <div class="landing-preset-icon">${escapeHtml(icon)}</div>
           <div class="landing-char-info">
             <div class="landing-char-name">${name}</div>
             <div class="landing-char-desc">${desc}</div>
@@ -157,10 +157,13 @@ function renderMessages() {
   const cardName = card.name || 'Assistant';
 
   // Resolve text/dialog colors
-  const userTextColor = persona.textColor || '';
-  const userDialogColor = persona.dialogColor || '';
-  const aiTextColor = card.textColor || '';
-  const aiDialogColor = card.dialogColor || '';
+  // Cards and personas can arrive from an imported file or a synced peer, and
+  // these four values land directly in style="color:..." attributes below.
+  // Allowlist the shapes a color picker produces; anything else becomes ''.
+  const userTextColor = safeCssColor(persona.textColor, '');
+  const userDialogColor = safeCssColor(persona.dialogColor, '');
+  const aiTextColor = safeCssColor(card.textColor, '');
+  const aiDialogColor = safeCssColor(card.dialogColor, '');
 
   // ── Branch origin banner ────────────────────────────────────────
   let branchBannerHtml = '';
@@ -178,9 +181,9 @@ function renderMessages() {
       const nextSib = siblings[myIdx + 1];
       sibNavHtml = `
         <div class="branch-sibling-nav">
-          <button class="branch-nav-btn" ${!prevSib ? 'disabled' : ''} onclick="switchToBranch('${prevSib ? prevSib.id : ''}')" title="Previous branch">◀</button>
+          <button class="branch-nav-btn" ${!prevSib ? 'disabled' : ''} onclick="switchToBranch('${prevSib ? escapeJsAttr(prevSib.id) : ''}')" title="Previous branch">◀</button>
           <span class="branch-nav-label">Branch ${myIdx + 1} / ${totalSibs}</span>
-          <button class="branch-nav-btn" ${!nextSib ? 'disabled' : ''} onclick="switchToBranch('${nextSib ? nextSib.id : ''}')" title="Next branch">▶</button>
+          <button class="branch-nav-btn" ${!nextSib ? 'disabled' : ''} onclick="switchToBranch('${nextSib ? escapeJsAttr(nextSib.id) : ''}')" title="Next branch">▶</button>
         </div>`;
     }
 
@@ -189,7 +192,7 @@ function renderMessages() {
         <span class="branch-origin-icon">⑂</span>
         <span class="branch-origin-label">
           Branched from
-          <button class="branch-origin-link" onclick="switchToBranch('${escapeHtml(thread.forkSource.threadId)}')">${sourceName}</button>
+          <button class="branch-origin-link" onclick="switchToBranch('${escapeJsAttr(thread.forkSource.threadId)}')">${sourceName}</button>
           at message ${forkAt + 1}
         </span>
         ${sibNavHtml}
@@ -308,7 +311,7 @@ function renderMessages() {
         <div class="${className} editing">
           <div class="msg-header">
             <span class="msg-avatar">${avatar}</span>
-            <span class="message-role">${roleLabel}</span>
+            <span class="message-role">${escapeHtml(roleLabel)}</span>
           </div>
           <textarea class="edit-textarea" id="edit-area">${escapeHtml(m.content || m.reasoning || '')}</textarea>
           <div class="edit-actions">
@@ -367,7 +370,7 @@ function renderMessages() {
     if (Array.isArray(m.attachments) && m.attachments.length) {
       attachmentsHtml = '<div class="msg-attachments">' + m.attachments.map(a => {
         if (a.kind === 'image' && a.dataUrl) {
-          return `<span class="msg-attach-chip" title="${escapeHtml(a.name)} — image, not sent to model"><img class="msg-attach-thumb" src="${a.dataUrl}" alt="${escapeHtml(a.name)}"><span>${escapeHtml(a.name)}</span></span>`;
+          return `<span class="msg-attach-chip" title="${escapeHtml(a.name)} — image, not sent to model"><img class="msg-attach-thumb" src="${escapeHtml(safeDataUrl(a.dataUrl))}" alt="${escapeHtml(a.name)}"><span>${escapeHtml(a.name)}</span></span>`;
         }
         const icon = a.kind === 'text' ? '📄' : (a.kind === 'image' ? '🖼️' : '⚠️');
         const note = a.kind === 'text' ? (a.truncated ? ' (truncated)' : '') : (a.kind === 'image' ? ' (not sent)' : ' (not sent)');
@@ -390,7 +393,7 @@ function renderMessages() {
       <div class="${className}" data-index="${i}">
         <div class="msg-header">
           <span class="msg-avatar">${avatar}</span>
-          <span class="message-role">${roleLabel}</span>
+          <span class="message-role">${escapeHtml(roleLabel)}</span>
           ${searchBadge}
           ${genBadges}
         </div>
@@ -416,7 +419,7 @@ function renderMessages() {
     const forksHere = getForksAt(thread.id, i + 1);
     if (forksHere.length === 0) return prefix + rowHtml;
     const forkBtns = forksHere.map(ft =>
-      `<button class="branch-fork-btn" onclick="switchToBranch('${ft.id}')" title="${escapeHtml(ft.name)}">⑂ ${escapeHtml(ft.name.replace(/^⑂\s*/, '').slice(0, 28))}</button>`
+      `<button class="branch-fork-btn" onclick="switchToBranch('${escapeJsAttr(ft.id)}')" title="${escapeHtml(ft.name)}">⑂ ${escapeHtml(ft.name.replace(/^⑂\s*/, '').slice(0, 28))}</button>`
     ).join('');
     return prefix + rowHtml + `
       <div class="branch-fork-line">

--- a/js/15-cards.js
+++ b/js/15-cards.js
@@ -88,18 +88,21 @@ function closeCharacters() {
 function renderCardGrid() {
   const grid = document.getElementById('card-grid');
   grid.innerHTML = state.characterCards.map(c => {
+    // Cards can arrive from an imported file or a synced peer, so the id is
+    // not necessarily the generated base-36 string it looks like.
+    const cid = escapeJsAttr(c.id);
     const av = renderAvatar(c.avatar, c.name);
     return `
-    <div class="card-item ${c.id === state.activeCardId ? 'active' : ''}" onclick="activateCard('${c.id}')">
+    <div class="card-item ${c.id === state.activeCardId ? 'active' : ''}" onclick="activateCard('${cid}')">
       <div class="card-avatar">${av}</div>
       <div class="card-info">
         <div class="card-name">${escapeHtml(c.name)}</div>
         <div class="card-desc">${escapeHtml((c.writingStyle || '').slice(0, 60))}</div>
       </div>
       <div class="card-actions">
-        <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editCard('${c.id}')">Edit</button>
-        <button class="msg-action-btn" onclick="event.stopPropagation();copyCard('${c.id}')" title="Duplicate this character">Copy</button>
-        ${state.characterCards.length > 1 ? `<button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deleteCardById('${c.id}')" title="Delete this character">Del</button>` : ''}
+        <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editCard('${cid}')">Edit</button>
+        <button class="msg-action-btn" onclick="event.stopPropagation();copyCard('${cid}')" title="Duplicate this character">Copy</button>
+        ${state.characterCards.length > 1 ? `<button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deleteCardById('${cid}')" title="Delete this character">Del</button>` : ''}
       </div>
     </div>`;
   }).join('');

--- a/js/17-personas.js
+++ b/js/17-personas.js
@@ -26,21 +26,22 @@ function renderPersonaGrid() {
       : freq === 1
         ? 'shared every turn'
         : `shared every ${freq} msgs`;
+    const pid = escapeJsAttr(p.id);
     const desc = (p.description || '').trim();
     const subline = desc
       ? `${escapeHtml(desc.slice(0, 50))}${desc.length > 50 ? '\u2026' : ''} \u00b7 ${freqLabel}`
       : freqLabel;
     return `
-    <div class="card-item ${p.id === state.activePersonaId ? 'active' : ''}" onclick="activatePersona('${p.id}')">
+    <div class="card-item ${p.id === state.activePersonaId ? 'active' : ''}" onclick="activatePersona('${pid}')">
       <div class="card-avatar">${av}</div>
       <div class="card-info">
         <div class="card-name">${escapeHtml(p.name || 'Unnamed')}</div>
         <div class="card-desc">${subline}</div>
       </div>
       <div class="card-actions">
-        <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editPersona('${p.id}')">Edit</button>
-        <button class="msg-action-btn" onclick="event.stopPropagation();copyPersona('${p.id}')" title="Duplicate this persona">Copy</button>
-        ${state.personaCards.length > 1 ? `<button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deletePersonaById('${p.id}')" title="Delete this persona">Del</button>` : ''}
+        <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editPersona('${pid}')">Edit</button>
+        <button class="msg-action-btn" onclick="event.stopPropagation();copyPersona('${pid}')" title="Duplicate this persona">Copy</button>
+        ${state.personaCards.length > 1 ? `<button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deletePersonaById('${pid}')" title="Delete this persona">Del</button>` : ''}
       </div>
     </div>`;
   }).join('');
@@ -244,7 +245,10 @@ function applyActiveCardBackground() {
   const msgArea = document.getElementById('messages');
   if (!msgArea) return;
   if (card.background && (card.background.startsWith('http') || card.background.startsWith('data:') || card.background.startsWith('file:'))) {
-    msgArea.style.backgroundImage = `url('${card.background}')`;
+    // Escape the CSS string delimiters so a background value cannot close the
+    // url() and steer the request somewhere else. http:// is deliberately
+    // supported here, so this only fixes the break-out, not the remote fetch.
+    msgArea.style.backgroundImage = `url('${String(card.background).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}')`;
     msgArea.style.backgroundSize = 'cover';
     msgArea.style.backgroundPosition = 'center';
     msgArea.style.backgroundRepeat = 'no-repeat';

--- a/js/18-utils.js
+++ b/js/18-utils.js
@@ -113,6 +113,53 @@ function escapeHtml(str) {
   return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+// For a value going into an inline handler: onclick="fn('${...}')".
+//
+// escapeHtml alone is NOT enough there. The HTML parser decodes character
+// references in an attribute value BEFORE the JS is compiled, so escapeHtml's
+// &#39; turns back into a real ' and closes the string literal -- the classic
+// way an "escaped" id or filename still ends up executing. Escape for the JS
+// layer first (backslash before quotes, or we'd double-escape our own output),
+// then run escapeHtml over the result for the attribute layer. \r \n and the
+// two Unicode line separators are terminators inside a JS string literal.
+function escapeJsString(str) {
+  return String(str == null ? '' : str)
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function escapeJsAttr(str) {
+  return escapeHtml(escapeJsString(str));
+}
+
+// Colors ride into style="color:${...}" attributes from character cards, which
+// can arrive from an imported file or a synced peer. Escaping is the wrong tool
+// for a CSS context -- allowlist the shapes a color picker actually produces and
+// drop anything else, so there is no value that reaches the CSS parser at all.
+// Avatars and attachment thumbnails are stored as data: URLs. Accepting any
+// string there lets an imported or synced card point <img src> at a remote host,
+// which beacons the viewer's IP the moment a message renders -- a real leak in an
+// app whose whole premise is that nothing leaves the machine. Allow only inline
+// image data (and blob:, which the attachment path creates locally).
+function safeDataUrl(value) {
+  const s = String(value == null ? '' : value).trim();
+  if (/^data:image\/(png|jpeg|jpg|gif|webp|bmp);base64,[A-Za-z0-9+/=\s]*$/i.test(s)) return s;
+  if (/^blob:/i.test(s)) return s;
+  return '';
+}
+
+const CSS_COLOR_RE = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,20}|rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*(?:,\s*(?:0|1|0?\.\d+)\s*)?\))$/;
+function safeCssColor(value, fallback) {
+  const s = String(value == null ? '' : value).trim();
+  if (CSS_COLOR_RE.test(s)) return s;
+  return fallback || '';
+}
+
 function parseSearchData(raw) {
   if (!raw) return '';
   // Parse the structured format: - Title: content\n  Source: url\n
@@ -168,6 +215,10 @@ function buildSearchEntry(title, content, url) {
 
 function parseMarkdown(text, dialogColor) {
   if (!text) return '';
+  // dialogColor rides in from a character card, which can arrive from an
+  // imported file or a synced peer, and lands in a style="color:..." attribute
+  // below. Allowlist it once here so no caller has to remember to.
+  dialogColor = safeCssColor(dialogColor, '');
   let html = escapeHtml(text);
 
   // File blocks: ```file:filename.ext → rendered with download + copy buttons
@@ -175,7 +226,7 @@ function parseMarkdown(text, dialogColor) {
     const fn = filename.trim();
     const raw = content.trim();
     const id = 'file_' + Math.random().toString(36).slice(2, 8);
-    return `<div class="file-block"><div class="file-header"><span class="file-name">&#128196; ${fn}</span><div class="code-btns"><button class="btn btn-sm code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><button class="btn btn-sm" onclick="downloadFile('${id}','${fn}')">Save</button></div></div><pre><code id="${id}">${raw}</code></pre></div>`;
+    return `<div class="file-block"><div class="file-header"><span class="file-name">&#128196; ${fn}</span><div class="code-btns"><button class="btn btn-sm code-copy-btn" onclick="copyCodeBlock(this)">Copy</button><button class="btn btn-sm" data-filename="${fn}" onclick="downloadFile(this)">Save</button></div></div><pre><code id="${id}">${raw}</code></pre></div>`;
   });
 
   // Regular code blocks → wrapped with a header bar carrying a Copy button.
@@ -417,7 +468,7 @@ function renderAttachTray() {
       <span class="attach-chip-icon">${icon}</span>
       <span class="attach-chip-name">${escapeHtml(a.name)}</span>
       <span class="attach-chip-meta">${escapeHtml(meta)}</span>
-      <button class="attach-chip-x" onclick="removeAttachment('${a.id}')" title="Remove">×</button>
+      <button class="attach-chip-x" onclick="removeAttachment('${escapeJsAttr(a.id)}')" title="Remove">×</button>
     </span>`;
   }).join('');
 }
@@ -531,9 +582,19 @@ function setupDragAndDrop() {
    FILE GENERATION — download .txt/.json to browser downloads
    AI outputs ```file:filename.ext blocks, rendered with Save button.
 ================================================================ */
-function downloadFile(elementId, filename) {
-  const el = document.getElementById(elementId);
+// Takes the button, not an id + filename pair. The filename comes from a
+// ```file:<name> fence, i.e. from model output or from a peer's message, and
+// interpolating it into onclick="downloadFile('...','<name>')" was exploitable:
+// parseMarkdown had already turned ' into &#39;, but the HTML parser decodes
+// character references in an attribute value before the JS is compiled, so the
+// entity became a real quote again and closed the string. Reading it off the
+// element -- the pattern copyCodeBlock already uses -- means the value never
+// passes through a JS parser at all.
+function downloadFile(btn) {
+  const block = btn && btn.closest && btn.closest('.file-block');
+  const el = block && block.querySelector('pre code');
   if (!el) return;
+  const filename = (btn.dataset && btn.dataset.filename) || 'download.txt';
   const content = el.textContent;
   const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
   const url = URL.createObjectURL(blob);

--- a/js/19-extensions.js
+++ b/js/19-extensions.js
@@ -232,16 +232,16 @@ function renderExtEntryList(kind) {
     <div class="ext-entry ${isStyle ? '' : 'ext-entry-script'}" data-ext-entry="${escapeHtml(e.id)}">
       <div class="ext-entry-head">
         <input type="text" class="ext-entry-name" placeholder="${isStyle ? 'Stylesheet' : 'Script'} ${i + 1} name (optional)" value="${escapeHtml(e.name || '')}">
-        <button class="btn btn-sm btn-danger" onclick="removeExtEntry('${kind}','${escapeHtml(e.id)}')">Remove</button>
+        <button class="btn btn-sm btn-danger" onclick="removeExtEntry('${kind}','${escapeJsAttr(e.id)}')">Remove</button>
       </div>
       <input type="text" class="ext-entry-url" placeholder="${urlPh}" value="${escapeHtml(e.url || '')}">
       <textarea class="ext-code-area ext-entry-raw" rows="${rows}" placeholder="${rawPh}">${escapeHtml(e.raw || '')}</textarea>
       <div style="display:flex;gap:8px;margin-top:6px;align-items:center;">
         <label class="avatar-file-btn" style="margin:0;">
           ${fileLabel}
-          <input type="file" accept="${accept}" style="display:none" onchange="handleExtFileEntry(this,'${kind}','${escapeHtml(e.id)}')">
+          <input type="file" accept="${accept}" style="display:none" onchange="handleExtFileEntry(this,'${kind}','${escapeJsAttr(e.id)}')">
         </label>
-        <button class="btn btn-sm" onclick="updateExtEntry('${kind}','${escapeHtml(e.id)}','raw','');renderExtEntries()">Clear inline</button>
+        <button class="btn btn-sm" onclick="updateExtEntry('${kind}','${escapeJsAttr(e.id)}','raw','');renderExtEntries()">Clear inline</button>
       </div>
     </div>
   `).join('');

--- a/js/20-macros.js
+++ b/js/20-macros.js
@@ -21,8 +21,8 @@ function renderMacroList() {
       <span class="macro-trigger">{{${escapeHtml(m.trigger)}}}</span>
       <span class="macro-preview">${escapeHtml(m.text.length > 64 ? m.text.slice(0, 61) + '...' : m.text)}</span>
       <div class="macro-actions">
-        <button class="btn btn-sm" onclick="editMacro('${escapeHtml(m.trigger)}')">Edit</button>
-        <button class="btn btn-sm btn-danger" onclick="deleteMacro('${escapeHtml(m.trigger)}')">Del</button>
+        <button class="btn btn-sm" onclick="editMacro('${escapeJsAttr(m.trigger)}')">Edit</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteMacro('${escapeJsAttr(m.trigger)}')">Del</button>
       </div>
     </div>
   `).join('');

--- a/js/22-scheduler.js
+++ b/js/22-scheduler.js
@@ -27,20 +27,21 @@ function renderSchedList() {
     return;
   }
   list.innerHTML = state.schedules.map(s => {
+    const sid = escapeJsAttr(s.id);
     const thread = state.threads.find(t => t.id === s.threadId);
     const threadName = thread ? escapeHtml(thread.name) : '(deleted thread)';
     const typeLabel = s.recurring === 'daily' ? 'DAILY' : 'ONCE';
     const searchLabel = s.useSearch ? ' 🔍' : '';
     return `
-      <div class="card-item" onclick="editSchedItem('${s.id}')">
+      <div class="card-item" onclick="editSchedItem('${sid}')">
         <div class="card-info">
-          <div class="card-name">${s.time} — ${typeLabel}${searchLabel}</div>
+          <div class="card-name">${escapeHtml(s.time)} — ${typeLabel}${searchLabel}</div>
           <div class="card-desc">${escapeHtml(s.prompt.slice(0, 60))} → ${threadName}</div>
         </div>
         <div class="card-actions">
-          <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editSchedItem('${s.id}')">Edit</button>
-          <button class="msg-action-btn" onclick="event.stopPropagation();copySched('${s.id}')" title="Duplicate this schedule">Copy</button>
-          <button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deleteSched('${s.id}')">Del</button>
+          <button class="msg-action-btn btn-edit" onclick="event.stopPropagation();editSchedItem('${sid}')">Edit</button>
+          <button class="msg-action-btn" onclick="event.stopPropagation();copySched('${sid}')" title="Duplicate this schedule">Copy</button>
+          <button class="msg-action-btn btn-delete" onclick="event.stopPropagation();deleteSched('${sid}')">Del</button>
         </div>
       </div>`;
   }).join('');


### PR DESCRIPTION
### The problem

`escapeHtml` (`js/18-utils.js:104`) is correctly written and applied to most display text. It was never applied to any `id` field, and was missed on several name and color fields. Those values aren't always self-authored — cards, personas, threads, tags and schedules all arrive from imported files and from the `/state` sync blob.

The one that matters most: `card.name` is read at `js/13-dashboard.js:157` and interpolated into the message header at `:393` with no escaping. A character card named with an `<img onerror=...>` payload runs script as soon as the card is activated.

That also walks around the guarantee in `js/23-card-code.js:30-33` that imported cards never auto-run their code. `applyImportedCardCode` correctly forces `customCodeEnabled = false`, but injected script can simply set it back and call `applyCardCode()`. The gate is real; the escaping around it wasn't.

**`escapeHtml` alone is also not sufficient inside an inline handler.** The HTML parser decodes character references in an attribute value *before* the JS is compiled, so `escapeHtml`'s `&#39;` becomes a real quote again and closes the string literal. Several call sites looked escaped and were not — `js/13-dashboard.js:195` and the three `escapeHtml(e.id)` uses in `js/19-extensions.js` are the clearest examples.

Other unescaped sinks reached from the same data: `${t.id}` into `data-thread-id` and seven inline handlers (`js/12-render.js:252-258`), `folder.id` (`:310-311`), tags (`:172`, `:179`), `c.id` / `p.id` / `s.id` in the card, persona and schedule grids, `s.time`, `activeModel.name`, and the attachment `dataUrl` in `<img src>`.

### The fix

- `escapeJsString` / `escapeJsAttr` — escape for the JS layer first, the attribute layer second. Used at every `on*=` interpolation.
- `safeCssColor` — colors go into `style="color:..."`, which isn't an HTML context, so this allowlists the shapes a color picker emits rather than escaping. Applied once where the four color values are read.
- `safeDataUrl` — attachment thumbnails accept inline image data and `blob:` only, so a synced message can't point `<img src>` at a remote host and beacon the viewer.
- `downloadFile` now takes the button and reads the filename off the element, the way `copyCodeBlock` already does. That removes the sink instead of escaping it, and fixes the `` ```file: `` fence being able to break out of its `onclick`.
- The folder-rename `querySelector` (`js/12-render.js:83`) goes through `CSS.escape`.

Card backgrounds still allow `http://` since that's a deliberate feature; only the quote break-out is fixed there.

### Testing

Helpers unit-tested against JS-string break-out, backslash, newline, HTML-tag and CSS break-out payloads. Every JS file parses clean, and a sweep confirms no `on*=` handler still takes a raw interpolation.

### Note

A CSP on `chat.html` would turn every remaining escaping miss from critical into cosmetic. I left it out because it conflicts with the inline-`onclick` render style and the extensions feature, so it's a much larger change and your call to make.

Found during a security review.