### PR TITLE
Never let transferred state arrive with code already enabled

### DIFF
--- a/js/06-state-sync.js
+++ b/js/06-state-sync.js
@@ -340,11 +340,29 @@ async function restoreFromServer(opts) {
       return false;
     }
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
-    const text = await resp.text();
+    let text = await resp.text();
     const mtimeHeader = resp.headers.get('X-State-Mtime');
     // Sanity-check: must parse and have at least the threads array
     const parsed = JSON.parse(text);
     if (!parsed || typeof parsed !== 'object') throw new Error('malformed backup');
+
+    // /state is a single shared document every paired device can overwrite, so
+    // this blob is not necessarily something this user wrote. Clear the flags
+    // that would make boot execute code out of it; the code itself is kept so
+    // it can be read and switched on here. See neutralizeUntrustedCode.
+    const neutralized = (typeof neutralizeUntrustedCode === 'function')
+      ? neutralizeUntrustedCode(parsed)
+      : { cards: 0, extensions: false };
+    if (neutralized.cards || neutralized.extensions) {
+      text = JSON.stringify(parsed);   // localStorage path writes the raw text
+      if (!opts.silent) {
+        alert('The server backup contained custom code set to run automatically' +
+              (neutralized.cards ? ' (' + neutralized.cards + ' character card(s))' : '') +
+              (neutralized.extensions ? ' and an extensions list' : '') +
+              '.\n\nIt was restored but left switched OFF. Review it in the ' +
+              'character editor or the extensions panel before enabling it.');
+      }
+    }
 
     // Loop stopper: a backup with no threads must NEVER trigger a reload. The
     // boot check treats "local has no threads" as a reason to restore, so

--- a/js/21-data.js
+++ b/js/21-data.js
@@ -151,12 +151,21 @@ function importData(fileInput, type) {
       state.schedules      = data.schedules      || [];
       state.folders        = data.folders        || [];
       state.extensions     = migrateExtensions(data.extensions);
+      // A backup file comes from wherever the user got it, and applyExtensions()
+      // below injects <script> from it while boot runs card code. Same rule as
+      // the character-card import: the content is kept, the run flags are not.
+      const neutralized = (typeof neutralizeUntrustedCode === 'function')
+        ? neutralizeUntrustedCode(state)
+        : { cards: 0, extensions: false };
       state.macros         = Array.isArray(data.macros) ? data.macros : DEFAULT_MACROS.map(m => ({ ...m }));
       state.searchEnabled  = data.searchEnabled  || false;
       saveState();
       applyExtensions();
       render();
-      showStatus('✓ Full backup restored successfully.', true);
+      const codeNote = (neutralized.cards || neutralized.extensions)
+        ? ' Custom code in the backup was kept but left switched OFF — review it before enabling.'
+        : '';
+      showStatus('✓ Full backup restored successfully.' + codeNote, true);
     }
 
     // Reset the file input so the same file can be re-imported if needed

--- a/js/23-card-code.js
+++ b/js/23-card-code.js
@@ -298,6 +298,60 @@ function updateCardCodeStatus() {
  * its author's JavaScript the moment you activate it. The code is kept
  * so it can be read and opted into; the flag is always cleared.
  */
+/**
+ * Strip the "and run it" bit out of a whole state blob that did not originate
+ * on this device.
+ *
+ * applyImportedCardCode below covers the character-card file import. It was the
+ * only door with a lock on it. Two others reach the same executors:
+ *
+ *   - restoreFromServer() in 06-state-sync.js writes the /state blob straight
+ *     into storage and reloads. /state is password-gated, but it is one shared
+ *     document every paired device can overwrite, so a compromised phone (or
+ *     anyone who learned the password) could hand every other device a card
+ *     with customCodeEnabled already true, or an extensions list, and boot
+ *     would run it. The restore that fires when local storage is empty does
+ *     not even prompt.
+ *   - importAllData('all') in 21-data.js takes a backup file from anywhere and
+ *     calls applyExtensions() in the same tick.
+ *
+ * The rule is the one applyImportedCardCode already documents: the decision to
+ * run code is made by the person at the keyboard, on this device, and cannot
+ * be carried in a transferred blob. Code text is preserved so it can be read
+ * and opted into; only the enable flags are cleared. Restores are rare (a new
+ * device, a cleared cache, a quota recovery) rather than part of the routine
+ * push, so the cost is re-ticking a box once per device.
+ *
+ * Returns a summary so the caller can tell the user what was switched off
+ * instead of doing it silently.
+ */
+function neutralizeUntrustedCode(blob) {
+  const result = { cards: 0, extensions: false };
+  if (!blob || typeof blob !== 'object') return result;
+
+  if (Array.isArray(blob.characterCards)) {
+    for (const card of blob.characterCards) {
+      if (!card || typeof card !== 'object') continue;
+      if (card.customCodeEnabled) result.cards++;
+      card.customCodeEnabled = false;
+    }
+  }
+
+  const ext = blob.extensions;
+  if (ext && typeof ext === 'object' && ext.enabled) {
+    ext.enabled = false;
+    result.extensions = true;
+  }
+
+  if (result.cards || result.extensions) {
+    console.warn('[card-code] Incoming state carried code set to run: ' +
+                 result.cards + ' card(s)' +
+                 (result.extensions ? ' and the extensions list' : '') +
+                 '. Kept, but switched OFF. Review it and enable it here if you want it.');
+  }
+  return result;
+}
+
 function applyImportedCardCode(card, rawCode) {
   if (typeof rawCode === 'string' && rawCode.trim()) {
     card.customCode = rawCode;


### PR DESCRIPTION
### The problem

`applyImportedCardCode` (`js/23-card-code.js:301`) documents the rule and enforces it on the character-card file import: the decision to run code belongs to the person at the keyboard and can't be carried in a transferred blob. Two other paths reach the same executors and had no such gate.

**`restoreFromServer()`** (`js/06-state-sync.js:376-381`) parses the `/state` blob and writes it straight into IndexedDB or localStorage, then reloads. Boot then calls `applyExtensions()` (`js/24-boot.js:43`) and `applyCardCode()` (`:46`) against it. `state.extensions.scripts[].raw` gets appended to `<head>` as a script element (`js/19-extensions.js:70`); `card.customCode` goes through `new Function` (`js/23-card-code.js:204`), gated only by `customCodeEnabled`, which survives the restore intact.

`/state` is password-gated, so this needs an authenticated peer — but it's a single shared document every paired device can overwrite. A compromised phone, or anyone who learned the shared password, can hand every other device code that runs at next boot. The restore that fires when local storage is empty (`js/06-state-sync.js:265`) doesn't prompt at all, which is exactly the state of a phone hitting a new DHCP address or a freshly cleared browser.

**`importAllData('all')`** (`js/21-data.js:122-157`) has the same shape: it assigns `characterCards` and `extensions` from an arbitrary backup file and calls `applyExtensions()` in the same tick, behind a `confirm()` that only mentions replacing data.

### The fix

`neutralizeUntrustedCode()`, added next to `applyImportedCardCode` and called on both paths. Code text is preserved so it can still be read and opted into; only the enable flags are cleared, and the user is told rather than it happening silently.

### On the cost

Restores are rare — a new device, a cleared cache, a quota recovery — rather than part of the routine push, which is a PUT from this device and unaffected. So the practical cost is re-ticking a box once per device, which is what the file-import path already asks for.

I considered preserving the flag when the incoming code is byte-identical to what's already enabled locally, which would remove even that cost. It's more moving parts for a case that only comes up on a device that already has the card, so I went with the simpler rule — happy to switch if you'd prefer.

### Testing

Unit-tested: enabled cards are disabled and their code kept, the extensions list is disabled and its scripts kept, `null` and `{}` are handled, and the call lands before `saveState()` / `applyExtensions()` on the import path.

Found during a security review.