### PR TITLE
Rate-limit login and hash the access password with PBKDF2

### DIFF
--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -93,10 +93,26 @@ $Script:JobWorkers = @{}  # jobId -> @{ PS; Handle; Runspace } for live runspace
 #   and constant-time compare to $AccessHash. The plaintext exists only for the
 #   instant a login request is being checked.
 # $LlmApiKey : optional key for llama-server (empty in the loopback build).
-$AccessSecret = Get-EnvOrDefault 'GEMMA_ACCESS_SECRET' ''
-$AccessSalt   = ''
-$AccessHash   = ''
-if ($AccessSecret -match '^([0-9a-fA-F]+):([0-9a-fA-F]+)$') {
+#
+# Two secret formats are accepted:
+#   pbkdf2-sha256:<iterations>:<salt-hex>:<hash-hex>   (what launch.bat writes now)
+#   <salt-hex>:<hash-hex>                              (legacy, single-round SHA-256)
+# The legacy form is still honoured so an existing install keeps working across
+# an update, but it is weak against offline cracking if .gobbonet-secret ever
+# leaks: one SHA-256 round over a short password is seconds of GPU work. Setting
+# a new password (delete .gobbonet-secret and re-run launch.bat) upgrades it.
+$AccessSecret     = Get-EnvOrDefault 'GEMMA_ACCESS_SECRET' ''
+$AccessKdf        = ''
+$AccessSalt       = ''
+$AccessIterations = 0
+$AccessHash       = ''
+if ($AccessSecret -match '^pbkdf2-sha256:(\d+):([0-9a-fA-F]+):([0-9a-fA-F]+)$') {
+    $AccessKdf        = 'pbkdf2-sha256'
+    $AccessIterations = [int]$Matches[1]
+    $AccessSalt       = $Matches[2].ToLower()
+    $AccessHash       = $Matches[3].ToLower()
+} elseif ($AccessSecret -match '^([0-9a-fA-F]+):([0-9a-fA-F]+)$') {
+    $AccessKdf  = 'sha256'
     $AccessSalt = $Matches[1].ToLower()
     $AccessHash = $Matches[2].ToLower()
 }
@@ -107,12 +123,88 @@ if ($AccessHash -eq '') {
 }
 $LlmApiKey = Get-EnvOrDefault 'GEMMA_LLM_API_KEY' ''
 
-# Compute the salted hash of a candidate password the same way launch.bat did.
+function ConvertFrom-HexString {
+    param([string]$Hex)
+    $bytes = New-Object byte[] ($Hex.Length / 2)
+    for ($i = 0; $i -lt $bytes.Length; $i++) {
+        $bytes[$i] = [Convert]::ToByte($Hex.Substring($i * 2, 2), 16)
+    }
+    return $bytes
+}
+
+# Compute the stored-hash form of a candidate password, using whichever KDF the
+# stored secret was written with. Constant work per call by design: PBKDF2 makes
+# each guess cost real CPU time, which is the half of brute-force resistance the
+# lockout below cannot provide (a stolen .gobbonet-secret is cracked offline,
+# where no lockout applies).
 function Get-PasswordHash {
     param([string]$Plain)
+    if ($AccessKdf -eq 'pbkdf2-sha256') {
+        $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes(
+            $Plain, (ConvertFrom-HexString $AccessSalt), $AccessIterations,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+        try { $bytes = $kdf.GetBytes(32) } finally { $kdf.Dispose() }
+        return (([BitConverter]::ToString($bytes) -replace '-').ToLower())
+    }
+    # Legacy format written by older launch.bat versions.
     $sha = [System.Security.Cryptography.SHA256]::Create()
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($AccessSalt + $Plain)
     return (([BitConverter]::ToString($sha.ComputeHash($bytes)) -replace '-').ToLower())
+}
+
+# --- Login throttling ---------------------------------------------------------
+# /login had no limit at all: anyone who can reach port 8080 could guess the
+# password as fast as they could send POSTs, and the launcher only asked for a
+# short one. Lock an address out after a few misses.
+#
+# Deliberately no artificial delay on a wrong password. The request loop below
+# is single-threaded, so a Start-Sleep here would hand an attacker a way to wedge
+# the whole server by flooding /login. Rejecting immediately once locked is both
+# cheaper for us and harder for them. The lock check also runs BEFORE the KDF,
+# so a flood cannot make us burn PBKDF2 time either.
+$Script:LoginFailures  = @{}   # client IP -> @{ Count; First; LockedUntil }
+$LoginMaxAttempts      = 5
+$LoginLockoutMinutes   = 15
+$LoginFailureWindowMin = 15
+
+function Get-ClientIp {
+    param($Request)
+    try { return $Request.RemoteEndPoint.Address.ToString() } catch { return 'unknown' }
+}
+
+# Returns the number of seconds still to wait, or 0 when not locked.
+function Get-LoginLockRemaining {
+    param([string]$Ip)
+    $rec = $Script:LoginFailures[$Ip]
+    if ($null -eq $rec -or $null -eq $rec.LockedUntil) { return 0 }
+    $left = ($rec.LockedUntil - (Get-Date)).TotalSeconds
+    if ($left -le 0) {
+        $Script:LoginFailures.Remove($Ip)
+        return 0
+    }
+    return [int][Math]::Ceiling($left)
+}
+
+function Register-LoginFailure {
+    param([string]$Ip)
+    $now = Get-Date
+    $rec = $Script:LoginFailures[$Ip]
+    # Start a fresh window if there was none, or the last one has aged out --
+    # otherwise a few typos spread over a week would eventually lock a real user.
+    if ($null -eq $rec -or ($now - $rec.First).TotalMinutes -gt $LoginFailureWindowMin) {
+        $rec = @{ Count = 0; First = $now; LockedUntil = $null }
+    }
+    $rec.Count++
+    if ($rec.Count -ge $LoginMaxAttempts) {
+        $rec.LockedUntil = $now.AddMinutes($LoginLockoutMinutes)
+        Write-Host ("[auth] {0} locked out for {1} min after {2} failed logins" -f $Ip, $LoginLockoutMinutes, $rec.Count)
+    }
+    $Script:LoginFailures[$Ip] = $rec
+}
+
+function Clear-LoginFailures {
+    param([string]$Ip)
+    if ($Script:LoginFailures.ContainsKey($Ip)) { $Script:LoginFailures.Remove($Ip) }
 }
 
 # Session tokens live in memory only -- restarting the server logs everyone out,
@@ -319,8 +411,12 @@ function Test-Authenticated {
 # Posts the password to /login; on success the server sets the cookie and the
 # page redirects to /.
 function Get-LoginPageHtml {
-    param([bool]$Failed)
-    $err = if ($Failed) { '<p class="err">Wrong password. Try again.</p>' } else { '' }
+    param([bool]$Failed, [int]$LockedSeconds = 0)
+    $err = if ($LockedSeconds -gt 0) {
+        ('<p class="err">Too many failed attempts. Try again in about {0} minute(s).</p>' -f [Math]::Ceiling($LockedSeconds / 60))
+    } elseif ($Failed) {
+        '<p class="err">Wrong password. Try again.</p>'
+    } else { '' }
     return @"
 <!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8">
@@ -1496,6 +1592,17 @@ while ($listener.IsListening) {
         # session cookie.
         if ($path -eq '/login') {
             if ($request.HttpMethod -eq 'POST') {
+                # Checked before the body is read and before the KDF runs, so a
+                # flood costs us nothing once the address is locked.
+                $clientIp = Get-ClientIp $request
+                $lockLeft = Get-LoginLockRemaining $clientIp
+                if ($lockLeft -gt 0) {
+                    $response.AddHeader('Retry-After', "$lockLeft")
+                    Write-Text $response 429 'text/html; charset=utf-8' `
+                        (Get-LoginPageHtml -Failed $false -LockedSeconds $lockLeft)
+                    $response.Close()
+                    continue
+                }
                 $body = ''
                 if ($request.HasEntityBody) {
                     $reader = New-Object System.IO.StreamReader($request.InputStream, $request.ContentEncoding)
@@ -1510,6 +1617,7 @@ while ($listener.IsListening) {
                     }
                 }
                 if (Test-SecretEqual (Get-PasswordHash $pw) $AccessHash) {
+                    Clear-LoginFailures $clientIp
                     $tok = New-SessionToken (Get-ClientId $request)
                     # HttpOnly: JS can't read it (blunts XSS token theft).
                     # SameSite=Lax + Path=/: sent on same-origin navigations and
@@ -1522,7 +1630,15 @@ while ($listener.IsListening) {
                     $response.StatusCode = 302
                     $response.AddHeader('Location', '/')
                 } else {
-                    Write-Text $response 401 'text/html; charset=utf-8' (Get-LoginPageHtml -Failed $true)
+                    Register-LoginFailure $clientIp
+                    $lockLeft = Get-LoginLockRemaining $clientIp
+                    if ($lockLeft -gt 0) {
+                        $response.AddHeader('Retry-After', "$lockLeft")
+                        Write-Text $response 429 'text/html; charset=utf-8' `
+                            (Get-LoginPageHtml -Failed $false -LockedSeconds $lockLeft)
+                    } else {
+                        Write-Text $response 401 'text/html; charset=utf-8' (Get-LoginPageHtml -Failed $true)
+                    }
                 }
             } else {
                 $code = 200

--- a/launch.bat
+++ b/launch.bat
@@ -309,7 +309,12 @@ exit /b
 
 :setup_password
 :: First-run password setup. Reads the password WITHOUT echoing, confirms it,
-:: enforces a minimum length, then writes a salted SHA-256 hash to SECRET_FILE.
+:: enforces a minimum length, then writes a PBKDF2-SHA256 hash to SECRET_FILE.
+:: PBKDF2 (210k iterations, the OWASP figure) rather than a single SHA-256
+:: round: the hash sits in a file on disk, and one round over a short password
+:: is seconds of GPU work if that file is ever read by anything else. The
+:: minimum is 10 characters because this password guards a service every
+:: device on the network can reach.
 :: All of this happens inside PowerShell so the plaintext never lands in a
 :: batch variable, the environment, or the console.
 ::
@@ -327,14 +332,18 @@ echo   This password protects the chat from anyone else on
 echo   your network. You'll enter it once here, then type it
 echo   on your phone/browser the first time you connect.
 echo.
-echo   It is stored only as a salted hash -- not as plain
-echo   text -- and never leaves this machine.
+echo   It is stored only as a slow salted hash -- not as
+echo   plain text -- and never leaves this machine.
+echo.
+echo   Use at least 10 characters, and not one you use
+echo   anywhere else: it crosses the LAN unencrypted.
 echo  ====================================================
 echo.
 set "GOBBONET_SECRET_OUT=!SECRET_FILE!"
 set "PW_SCRIPT=%TEMP%\gobbonet_setpw_%RANDOM%.ps1"
 (
-echo $min = 6
+echo $min = 10
+echo $iters = 210000
 echo while ^($true^) {
 echo     $p1 = Read-Host 'Enter a password' -AsSecureString
 echo     $b1 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR^($p1^)
@@ -349,10 +358,10 @@ echo     if ^($t1 -ne $t2^) { Write-Host '  Passwords did not match -- try again
 echo     $saltBytes = New-Object byte[] 16
 echo     [Security.Cryptography.RandomNumberGenerator]::Create^(^).GetBytes^($saltBytes^)
 echo     $salt = ^([BitConverter]::ToString^($saltBytes^) -replace '-'^).ToLower^(^)
-echo     $sha = [Security.Cryptography.SHA256]::Create^(^)
-echo     $bytes = [Text.Encoding]::UTF8.GetBytes^($salt + $t1^)
-echo     $hash = ^([BitConverter]::ToString^($sha.ComputeHash^($bytes^)^) -replace '-'^).ToLower^(^)
-echo     Set-Content -Path $env:GOBBONET_SECRET_OUT -Value ^($salt + ':' + $hash^) -Encoding ascii -NoNewline
+echo     $kdf = New-Object System.Security.Cryptography.Rfc2898DeriveBytes^($t1, $saltBytes, $iters, [System.Security.Cryptography.HashAlgorithmName]::SHA256^)
+echo     $hash = ^([BitConverter]::ToString^($kdf.GetBytes^(32^)^) -replace '-'^).ToLower^(^)
+echo     $kdf.Dispose^(^)
+echo     Set-Content -Path $env:GOBBONET_SECRET_OUT -Value ^('pbkdf2-sha256:' + $iters + ':' + $salt + ':' + $hash^) -Encoding ascii -NoNewline
 echo     Write-Host '  [OK] Password set.' -Foreground Green
 echo     break
 echo }
@@ -368,7 +377,9 @@ set "GOBBONET_SECRET_OUT="
 :: return empty. Every one of those used to surface as "No password was
 :: set. Cannot start securely." several lines later, with no hint why.
 ::
-:: The file must be one line of <hex>:<hex> -- that is exactly what
+:: The file must be one line of pbkdf2-sha256:<iters>:<hex>:<hex> (or the
+:: legacy <hex>:<hex>, still accepted so an existing install keeps working)
+:: -- that is exactly what
 :: fileserver.ps1 parses at startup, so if it does not match here it was
 :: never going to work there either.
 set "PW_OK="
@@ -396,7 +407,7 @@ if not defined HAVE_PS goto :pw_batch_check
 :: Ask the consumer's own question. Passing through an environment variable
 :: rather than interpolating keeps a malformed secret off the command line.
 set "GN_PWCHECK=!PW_LINE!"
-powershell -NoProfile -Command "if ($env:GN_PWCHECK -match '^([0-9a-fA-F]+):([0-9a-fA-F]+)$') { exit 0 } else { exit 1 }" >nul 2>&1
+powershell -NoProfile -Command "if ($env:GN_PWCHECK -match '^pbkdf2-sha256:\d+:[0-9a-fA-F]+:[0-9a-fA-F]+$' -or $env:GN_PWCHECK -match '^[0-9a-fA-F]+:[0-9a-fA-F]+$') { exit 0 } else { exit 1 }" >nul 2>&1
 if not errorlevel 1 set "PW_OK=1"
 set "GN_PWCHECK="
 goto :pw_verdict


### PR DESCRIPTION
### The problem

`/login` (`fileserver.ps1:1497`) had no limit of any kind — anyone who can reach port 8080 could guess the password as fast as they could send POSTs, and `launch.bat:337` only required six characters. The password also went through a single salted SHA-256 round (`fileserver.ps1:111`), so a copy of `.gobbonet-secret` is cheap to crack offline.

Both halves need fixing: a lockout does nothing for a stolen hash file, and a slow KDF does nothing for unlimited online guesses.

### The fix

**Server.** Five failures from one address inside fifteen minutes locks that address out for fifteen, answered with 429 and `Retry-After`. Failures clear on a successful login and the window resets once it ages out, so occasional typos never accumulate.

Two deliberate details:

- **No sleep on a wrong password.** The request loop is single-threaded, so a delay would hand an attacker a way to wedge the whole server by flooding `/login`. Rejecting immediately once locked is cheaper for us and harder for them.
- **The lock is checked before the body is read and before the KDF runs**, so a flood can't make us burn PBKDF2 time either.

**Launcher.** Passwords are stored as `pbkdf2-sha256:<iterations>:<salt>:<hash>` at 210k iterations (the OWASP figure, ~0.6s on Windows PowerShell 5.1), and the minimum length goes from 6 to 10.

**Compatibility.** The server accepts the legacy `<salt>:<hash>` form as well, so existing installs keep working across the update — setting a new password upgrades the format. The startup validator and its batch-only fallback accept both.

The plaintext handling was already careful and is untouched: it stays inside PowerShell as a `SecureString`, is zeroed, and only the derived hash is written or passed on.

### Testing

Verified end-to-end under Windows PowerShell 5.1 by generating a secret through the exact script `launch.bat` emits, then checking it against the server's parser: new-format secrets verify, legacy secrets still verify, wrong passwords fail on both. Lockout confirmed to trigger on the sixth attempt, block before the KDF, apply per-address, and clear on success.

### Still open

The single-threaded request loop is a separate issue — one long-held request blocks every other client. Out of scope here, but worth knowing about since it's why the lockout is built the way it is.

Found during a security review.