### PR TITLE
Scope the URL ACLs to one account and stop widening system firewall rules

### DIFF
--- a/setup-lan.bat
+++ b/setup-lan.bat
@@ -44,24 +44,23 @@ echo.
 :: ---------------------------------------------------------------
 echo  [..] Adding firewall rules...
 
+:: Ports 11434 (llama-server) and 11435 (search proxy) do NOT get a rule.
+:: Both bind 127.0.0.1 only -- launch.bat passes --host 127.0.0.1 and the
+:: proxy listens on http://127.0.0.1:11435/ -- so nothing on the LAN can
+:: reach them and an inbound rule only stands to expose whatever else might
+:: bind those ports later. Only 8080, the file server the phone actually
+:: talks to, needs to be reachable. Earlier versions did open them, so they
+:: are removed here rather than left behind.
 netsh advfirewall firewall show rule name="Gemma4-LLM" >nul 2>&1
-if errorlevel 1 (
-    netsh advfirewall firewall add rule name="Gemma4-LLM" dir=in action=allow protocol=TCP localport=11434 profile=private,public remoteip=LocalSubnet >nul
-    echo  [OK] Firewall rule added: Gemma4-LLM (port 11434, llama.cpp, local subnet only)
-) else (
-    rem Repair any pre-existing (possibly wide-open) rule from an older run.
-    netsh advfirewall firewall set rule name="Gemma4-LLM" new dir=in action=allow protocol=TCP localport=11434 profile=private,public remoteip=LocalSubnet >nul
-    echo  [OK] Firewall rule updated: Gemma4-LLM (re-scoped to local subnet only)
+if not errorlevel 1 (
+    netsh advfirewall firewall delete rule name="Gemma4-LLM" >nul
+    echo  [OK] Firewall rule removed: Gemma4-LLM ^(port 11434 is loopback-only^)
 )
 
 netsh advfirewall firewall show rule name="Gemma4-Search" >nul 2>&1
-if errorlevel 1 (
-    netsh advfirewall firewall add rule name="Gemma4-Search" dir=in action=allow protocol=TCP localport=11435 profile=private,public remoteip=LocalSubnet >nul
-    echo  [OK] Firewall rule added: Gemma4-Search (port 11435, search proxy, local subnet only)
-) else (
-    rem Repair any pre-existing (possibly wide-open) rule from an older run.
-    netsh advfirewall firewall set rule name="Gemma4-Search" new dir=in action=allow protocol=TCP localport=11435 profile=private,public remoteip=LocalSubnet >nul
-    echo  [OK] Firewall rule updated: Gemma4-Search (re-scoped to local subnet only)
+if not errorlevel 1 (
+    netsh advfirewall firewall delete rule name="Gemma4-Search" >nul
+    echo  [OK] Firewall rule removed: Gemma4-Search ^(port 11435 is loopback-only^)
 )
 
 netsh advfirewall firewall show rule name="Gemma4-Web" >nul 2>&1
@@ -96,16 +95,16 @@ echo.
 :: IP rotations (same hostname = same origin). No more lost chats
 :: when DHCP hands out a new lease.
 :: ---------------------------------------------------------------
-echo  [..] Enabling mDNS (.local hostname) on Private + Public profiles...
+echo  [..] Enabling mDNS (.local hostname) on the Private profile...
 
-netsh advfirewall firewall set rule name="mDNS (UDP-In)" new enable=yes profile=private,public >nul 2>&1
+netsh advfirewall firewall set rule name="mDNS (UDP-In)" new enable=yes >nul 2>&1
 if errorlevel 1 (
     :: Older builds may not have the canonical rule name. Add a fresh
     :: one as a fallback so the .local hostname still works -- scoped
     :: to private + local subnet to match the service rules.
     netsh advfirewall firewall show rule name="Gemma4-mDNS" >nul 2>&1
     if errorlevel 1 (
-        netsh advfirewall firewall add rule name="Gemma4-mDNS" dir=in action=allow protocol=UDP localport=5353 profile=private,public remoteip=LocalSubnet >nul
+        netsh advfirewall firewall add rule name="Gemma4-mDNS" dir=in action=allow protocol=UDP localport=5353 profile=private remoteip=LocalSubnet >nul
         echo  [OK] Firewall rule added: Gemma4-mDNS (UDP 5353, .local resolution, local subnet only)
     ) else (
         echo  [OK] Firewall rule already exists: Gemma4-mDNS
@@ -135,23 +134,23 @@ echo.
 :: a driver rollback) wipes UrlAclInfo from the registry, the script
 :: looked successful but did nothing. The new check actually works.
 :: ---------------------------------------------------------------
+::
+:: SCOPE: these reservations used to be granted to `Everyone`, which is a
+:: permanent, machine-wide grant letting ANY local account -- including a
+:: low-privilege or service account -- bind those ports on every interface.
+:: An account that starts first could squat 8080 and serve a look-alike login
+:: page to phones on the LAN, harvesting the chat password. The reservation is
+:: now granted to the single account running the setup. Older installs that
+:: still carry the Everyone grant are detected and re-scoped below.
 echo  [..] Adding URL ACL reservations...
 
-netsh http show urlacl url=http://+:11435/ | findstr /i "Reserved URL" >nul
-if errorlevel 1 (
-    netsh http add urlacl url=http://+:11435/ user=Everyone >nul
-    echo  [OK] URL ACL added: http://+:11435/ (search proxy)
-) else (
-    echo  [OK] URL ACL already exists: http://+:11435/
-)
+set "ACL_USER=%USERDOMAIN%\%USERNAME%"
+echo       Granting to: %ACL_USER%
+echo       (this must be the account you run launch.bat as -- if you elevated
+echo        with a different admin account, re-run this from your own account)
 
-netsh http show urlacl url=http://+:8080/ | findstr /i "Reserved URL" >nul
-if errorlevel 1 (
-    netsh http add urlacl url=http://+:8080/ user=Everyone >nul
-    echo  [OK] URL ACL added: http://+:8080/ (file server)
-) else (
-    echo  [OK] URL ACL already exists: http://+:8080/
-)
+call :ensure_urlacl 11435 "search proxy"
+call :ensure_urlacl 8080 "file server"
 
 echo.
 echo  ====================================================
@@ -168,8 +167,6 @@ echo.
 echo   launch.bat will show the exact URLs when it starts.
 echo.
 echo   To UNDO these changes later, run:
-echo     netsh advfirewall firewall delete rule name="Gemma4-LLM"
-echo     netsh advfirewall firewall delete rule name="Gemma4-Search"
 echo     netsh advfirewall firewall delete rule name="Gemma4-Web"
 echo     netsh advfirewall firewall delete rule name="Gemma4-mDNS"
 echo     netsh http delete urlacl url=http://+:11435/
@@ -177,3 +174,24 @@ echo     netsh http delete urlacl url=http://+:8080/
 echo  ====================================================
 echo.
 pause
+
+goto :eof
+
+:ensure_urlacl
+:: %1 = port, %2 = description. Adds the reservation for %ACL_USER%, and
+:: replaces an existing one that was granted to Everyone.
+netsh http show urlacl url=http://+:%~1/ | findstr /i "Reserved URL" >nul
+if errorlevel 1 (
+    netsh http add urlacl url=http://+:%~1/ user=%ACL_USER% >nul
+    echo  [OK] URL ACL added: http://+:%~1/ ^(%~2^)
+    exit /b
+)
+netsh http show urlacl url=http://+:%~1/ | findstr /i "Everyone" >nul
+if errorlevel 1 (
+    echo  [OK] URL ACL already scoped: http://+:%~1/ ^(%~2^)
+    exit /b
+)
+netsh http delete urlacl url=http://+:%~1/ >nul
+netsh http add urlacl url=http://+:%~1/ user=%ACL_USER% >nul
+echo  [OK] URL ACL re-scoped: http://+:%~1/ ^(%~2 -- was Everyone^)
+exit /b


### PR DESCRIPTION
Three separate over-reaches in `setup-lan.bat`. Grouped because they're all one file and one theme, but happy to split if you'd rather review them apart.

### 1. `user=Everyone` on the URL reservations

`setup-lan.bat:142,150` ran `netsh http add urlacl url=http://+:PORT/ user=Everyone` for 8080 and 11435. That's a permanent, machine-wide grant letting any local account — including a low-privilege or service account — bind those ports on every interface. An account that starts before the real server could squat 8080 and serve a look-alike login page to phones on the LAN, harvesting the chat password.

Now granted to the account running the setup. An existing `Everyone` grant is detected and replaced rather than reported as "already exists", so re-running fixes an affected install. The account is printed, since elevating with a *different* admin account would grant it to the wrong one — worth seeing before it happens.

The reservation URL itself is unchanged (`http://+:PORT/`), only the grantee.

### 2. The built-in mDNS rule was widened to the Public profile

`setup-lan.bat:101` ran `set rule name="mDNS (UDP-In)" new enable=yes profile=private,public`. That rule isn't ours — changing it affects every application using mDNS, applies on untrusted networks, and wasn't in the undo instructions.

Both the comment above it and the message it prints already said Private only; the command was the odd one out. It now enables the rule without touching its profile scope, and the fallback `Gemma4-mDNS` rule is Private-only.

### 3. LAN rules for two loopback-only services

Ports 11434 and 11435 were opened to the local subnet, but both services bind `127.0.0.1` — `launch.bat:1389` passes `--host 127.0.0.1`, and the search proxy listens on `http://127.0.0.1:11435/`. Nothing on the LAN could reach them; the rules only stood to expose whatever else might bind those ports later.

Removed rather than left behind, so re-running cleans up an existing install. Only 8080, the port the phone actually talks to, keeps a rule. Undo instructions updated to match.

### Testing

Dry-run with `netsh` stubbed out, confirming the new `:ensure_urlacl` subroutine dispatches correctly, `%ACL_USER%` resolves, and both the add and the re-scope branches behave. Note the existing rules were already correctly scoped to `remoteip=LocalSubnet` — that part was solid and is untouched.

Found during a security review.