### PR TITLE
Fall back to loopback when the LAN bind is denied, so desktop chat still works

### DIFF
--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -51,7 +51,12 @@ $SearchPort   = [int](Get-EnvOrDefault 'GEMMA_SEARCH_PORT'   '11435')
 # Embedding service (RAG Retriever A). Optional infra: if it's down, the
 # /embed proxy below returns 502 and chat.html degrades to tag-only retrieval.
 $EmbedPort    = [int](Get-EnvOrDefault 'GEMMA_EMBED_PORT'    '11436')
-$ListenPort   = 8080
+# Port is overridable because 8080 is not always available in a way netstat can
+# show: Hyper-V, WSL and Docker Desktop RESERVE port ranges, and a bind inside one
+# fails with "forbidden by its access permissions" while nothing is listening. The
+# launcher passes this through, so a user who hits that can move off 8080 without
+# editing a script.
+$ListenPort   = [int](Get-EnvOrDefault 'GEMMA_FILE_PORT'     '8080')
 $ServerExe    = Get-EnvOrDefault 'GEMMA_SERVER_EXE'     ''
 $ModelDir     = Get-EnvOrDefault 'GEMMA_MODEL_DIR'      (Join-Path $Root 'models')
 $CtxSize      = [int](Get-EnvOrDefault 'GEMMA_CTX_SIZE'      '16384')
@@ -1449,17 +1454,55 @@ function Handle-SwapStatus {
 # Make sure System.Web is available for UrlDecode.
 Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue
 
+# Bind the LAN prefix if we can, and fall back to loopback if we cannot.
+#
+# `http://+:PORT/` goes through HTTP.sys and needs a URL ACL reservation, so an
+# ordinary (non-elevated) user gets "Access is denied" -- for ANY port, which is
+# why moving off 8080 does not help this case. `http://127.0.0.1:PORT/` needs no
+# reservation at all. Verified on one machine, same user, same moment:
+#     http://127.0.0.1:8797/ -> bound
+#     http://+:8798/         -> Access is denied
+#
+# Before this fallback the whole app died there. That is the wrong outcome,
+# because the file server SERVES THE CHAT PAGE: a user with no URL ACL lost
+# desktop chat entirely, while the model on :11434 stayed healthy -- which makes
+# it look like a front-end bug. Phone access genuinely needs the reservation;
+# desktop chat never did.
 $listener = New-Object System.Net.HttpListener
 $listener.Prefixes.Add("http://+:$ListenPort/")
+$LanBound = $true
 try {
     $listener.Start()
 } catch {
-    Write-Host ("[fatal] could not bind http://+:{0}/ -- {1}" -f $ListenPort, $_.Exception.Message)
-    Write-Host '         Run setup-lan.bat as Administrator to add the URL ACL.'
-    exit 1
+    $wildcardError = $_.Exception.Message
+    $listener = New-Object System.Net.HttpListener
+    $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
+    try {
+        $listener.Start()
+        $LanBound = $false
+        Write-Host ("[warn] could not bind http://+:{0}/ -- {1}" -f $ListenPort, $wildcardError)
+        Write-Host  '       Listening on 127.0.0.1 instead: desktop chat WORKS, phone/LAN access does not.'
+        Write-Host  '       To enable phone access, run setup-lan.bat as Administrator (adds the URL ACL).'
+    } catch {
+        Write-Host ("[fatal] could not bind http://+:{0}/ -- {1}" -f $ListenPort, $wildcardError)
+        Write-Host ("[fatal] loopback http://127.0.0.1:{0}/ also failed -- {1}" -f $ListenPort, $_.Exception.Message)
+        Write-Host  '         If that says "forbidden by its access permissions", the port sits inside a'
+        Write-Host  '         Windows reserved range (Hyper-V / WSL / Docker Desktop). netstat shows nothing'
+        Write-Host  '         listening because nothing is -- the range is RESERVED. Check with:'
+        Write-Host  '           netsh interface ipv4 show excludedportrange protocol=tcp'
+        Write-Host  '         then set GEMMA_FILE_PORT to a port outside every listed range.'
+        exit 1
+    }
 }
 
-Write-Host ("[ok] listening on http://+:{0}/" -f $ListenPort)
+# Report the prefix actually bound. Printing the wildcard form after falling back
+# to loopback would tell the user phone access is available when it is not -- the
+# same shape of wrong-but-reassuring status this fallback exists to remove.
+if ($LanBound) {
+    Write-Host ("[ok] listening on http://+:{0}/ (LAN + phone access)" -f $ListenPort)
+} else {
+    Write-Host ("[ok] listening on http://127.0.0.1:{0}/ (this machine only)" -f $ListenPort)
+}
 Write-Host ("[ok] access password required (salted-hash verified; set via launch.bat)")
 Write-Host ("[ok] detached generation jobs enabled (spool: {0})" -f $JobsDir)
 if ($LlmApiKey -eq '') {

--- a/launch.bat
+++ b/launch.bat
@@ -1665,15 +1665,41 @@ set "GEMMA_KV_CACHE_TYPE=!KV_CACHE_TYPE!"
 set "GEMMA_LOG_FILE=!LOG_FILE!"
 set "GEMMA_LAUNCH_SCRIPT=!LAUNCH_SCRIPT!"
 set "GEMMA_ACCESS_SECRET=!ACCESS_SECRET!"
-start /min powershell -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%~dp0fileserver.ps1"
+:: Capture the file server's own output. It prints the EXACT bind error --
+:: "[fatal] could not bind http://+:8080/ -- <reason>" -- but -WindowStyle Hidden
+:: sent that to a window nobody can read, which closes on exit. The one line that
+:: distinguishes "URL ACL missing" from "the port is reserved by Hyper-V/WSL" from
+:: anything else was being thrown away, so a user could only report "it failed".
+start /min "" cmd /c "powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0fileserver.ps1" > "%~dp0fileserver.log" 2>&1"
 
 set "FRETRIES=0"
 :fserver_wait
 set /a FRETRIES+=1
 if !FRETRIES! gtr 8 (
-    echo  [*] File server failed to start. Phone access will not work.
-    echo      You may need to run setup-lan.bat as Administrator first.
-    echo      Desktop chat still works normally.
+    echo  [*] File server failed to start.
+    echo.
+    :: The file server SERVES THE CHAT PAGE. If it is down there is no UI at all,
+    :: so the old "Desktop chat still works normally" line was not just unhelpful,
+    :: it sent people looking in the wrong place. The model on :11434 being healthy
+    :: is exactly what makes that message believable and wrong.
+    echo      Chat is NOT available - this server hosts the page itself.
+    echo.
+    if exist "%~dp0fileserver.log" (
+        echo      Reason reported by the file server:
+        for /f "usebackq delims=" %%L in ("%~dp0fileserver.log") do echo        %%L
+        echo.
+        echo      Full log: %~dp0fileserver.log
+    ) else (
+        echo      No log was written - the file server did not start at all.
+    )
+    echo.
+    echo      Common causes:
+    echo        * "Access is denied"  - run setup-lan.bat as Administrator (URL ACL).
+    echo        * "forbidden by its access permissions" - port 8080 sits inside a
+    echo          Windows reserved range (Hyper-V / WSL / Docker Desktop). Check with:
+    echo            netsh interface ipv4 show excludedportrange protocol=tcp
+    echo          netstat shows nothing listening, because nothing is - the range is
+    echo          RESERVED, not in use. Set GEMMA_FILE_PORT to a free port.
     goto :get_lan_ip
 )
 timeout /t 1 /nobreak >nul


### PR DESCRIPTION
Reported today: "File server failed to start ... Desktop chat still works normally" -- except it did not. The user's browser could not reach :8080, netstat showed nothing on the port, they had already run setup-lan.bat, and the model on :11434 was answering fine.

Root cause: fileserver binds `http://+:8080/`. That prefix goes through HTTP.sys and needs a URL ACL reservation, so a non-elevated user gets "Access is denied" -- for ANY port, which is why changing the port does not help. Measured on one machine, same user, same moment:

    http://127.0.0.1:8797/ -> bound
    http://+:8798/         -> Access is denied

Loopback needs no reservation. So the server now tries the LAN prefix, and falls back to 127.0.0.1 instead of exiting. Desktop chat works with no admin; phone access still needs setup-lan.bat, which is the honest split -- it always was the only part that needed the reservation.

Three smaller things in the same path, all of which made this hard to diagnose:

- The launcher started fileserver.ps1 with -WindowStyle Hidden, so its "[fatal] could not bind ... -- <reason>" line went to a window nobody can read, which then closed. The one line that separates "URL ACL missing" from "the port is inside a Windows reserved range" was being thrown away, leaving users able to report only "it failed". Output is now captured to fileserver.log and printed.

- "Desktop chat still works normally" was false whenever this happened: the file server SERVES THE CHAT PAGE. With the model still healthy on :11434, that line sent people looking at the front end. It now says chat is unavailable, and with the fallback above it is usually not reached at all.

- "[ok] listening on http://+:PORT/" printed the wildcard form even after falling back, telling the user phone access worked when it did not.

Also adds GEMMA_FILE_PORT (via the file's existing Get-EnvOrDefault) for the OTHER cause of a failed bind: Hyper-V, WSL and Docker Desktop RESERVE port ranges, and a bind inside one fails with "forbidden by its access permissions" while netstat shows nothing listening -- because nothing is; the range is reserved. `netsh interface ipv4 show excludedportrange protocol=tcp` lists them.

Verified as a non-elevated user: the wildcard bind is denied, the fallback binds, the server reports "listening on http://127.0.0.1:PORT/ (this machine only)", and the page serves (401 = the access-password gate, which is correct). Before this, the same run exited 1 and served nothing.