### PR TITLE
Search without an Ollama account: a provider seam inside Handle-Search

### DIFF
--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -1536,6 +1536,91 @@ function Handle-Search {
     $reader = New-Object System.IO.StreamReader($Request.InputStream, [System.Text.Encoding]::UTF8)
     $body = $reader.ReadToEnd(); $reader.Close()
 
+    # ---- provider seam ----------------------------------------------------
+    #
+    # Search is hardcoded to ollama.com and forwards the caller's Authorization,
+    # so it only works for someone with an Ollama account and a key pasted into
+    # settings. Everyone else gets an upstream 401, which surfaces as "search is
+    # broken" rather than "you need an account you were never asked for".
+    #
+    # DEFAULT IS UNCHANGED. With SEARCH_URL unset this is the same request to the
+    # same host with the same header, so no existing install moves. Set
+    # SEARCH_URL and search goes to whatever you run -- a local SearxNG, your own
+    # service -- with no key unless yours needs one.
+    #
+    # SEARCH_PROVIDER pins the choice for the two cases 'auto' cannot serve:
+    # keeping Ollama even with SEARCH_URL set, and treating a missing SEARCH_URL
+    # as an ERROR rather than a quiet fallback (below), which is what you want
+    # once a self-hosted backend is the thing you rely on.
+    $provider = $env:SEARCH_PROVIDER
+    if (-not $provider) { $provider = 'auto' }
+    if ($provider -eq 'auto') {
+        $provider = if ($env:SEARCH_URL) { 'http' } else { 'ollama' }
+    }
+
+    if ($provider -eq 'http') {
+        # Deliberately NOT implemented here. A hand-rolled scraper goes stale
+        # silently -- it returns an empty list rather than an error, so the UI
+        # says "found nothing" for as long as nobody checks. Forward to something
+        # whose job search is.
+        if (-not $env:SEARCH_URL) {
+            Write-Json $Response 502 @{ error = 'search: SEARCH_PROVIDER=http but SEARCH_URL is not set' }
+            return
+        }
+        $query = ''
+        $max = 5
+        try {
+            $req = $body | ConvertFrom-Json -ErrorAction Stop
+            if ($req.query)       { $query = [string]$req.query }
+            if ($req.max_results) { $max   = [int]$req.max_results }
+        } catch {
+            Write-Json $Response 400 @{ error = 'search: request body was not valid JSON' }
+            return
+        }
+        $headers = @{ 'Content-Type' = 'application/json' }
+        # Forwarded only if the caller sent one: a self-hosted backend usually
+        # needs no key, and sending an empty header is not the same as sending none.
+        $auth = $Request.Headers['Authorization']
+        if ($auth) { $headers['Authorization'] = $auth }
+        try {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            $payload = @{ query = $query; max_results = $max } | ConvertTo-Json -Compress
+            $wr = Invoke-WebRequest -Uri $env:SEARCH_URL -Method POST -Body $payload `
+                                    -Headers $headers -UseBasicParsing -TimeoutSec 25
+            # Decode explicitly. Invoke-WebRequest only hands back a STRING when
+            # the response declares a text content type; a backend that omits
+            # Content-Type yields bytes, and piping those to ConvertFrom-Json
+            # produces no `results` rather than an error -- so the search returns
+            # an empty list and reads as "found nothing" instead of "misread the
+            # reply". Caught by test-search-seam.ps1, which stubs a backend that
+            # sends no Content-Type precisely because that is the quiet case.
+            $raw = $wr.Content
+            if ($raw -isnot [string]) { $raw = [System.Text.Encoding]::UTF8.GetString($raw) }
+            $j = $raw | ConvertFrom-Json -ErrorAction Stop
+            $out = @()
+            foreach ($item in $j.results) {
+                if ($out.Count -ge $max) { break }
+                # Three names for one field. SearxNG says `content`, most engines
+                # say `snippet`, some say `description`. Reading only `content` is
+                # how a WORKING backend renders every row with an empty body --
+                # titles and links appear, snippets are blank, and it reads as the
+                # model ignoring the results rather than a field-name mismatch.
+                $text = $item.content
+                if (-not $text) { $text = $item.snippet }
+                if (-not $text) { $text = $item.description }
+                $out += @{ title = [string]$item.title; url = [string]$item.url; content = [string]$text }
+            }
+            # @() so a single result still serialises as an array; ConvertTo-Json
+            # unwraps a one-element array and the client would get an object where
+            # it iterates a list.
+            Write-Json $Response 200 @{ results = @($out) }
+        } catch {
+            $msg = $_.Exception.Message -replace '"','' -replace "`r",'' -replace "`n",' '
+            Write-Json $Response 502 @{ error = ('search: ' + $msg) }
+        }
+        return
+    }
+
     $target = 'https://ollama.com/api' + $SubPath
     $headers = @{ 'Content-Type' = 'application/json' }
 

--- a/test-search-seam.ps1
+++ b/test-search-seam.ps1
@@ -1,0 +1,113 @@
+# Drives the REAL Handle-Search out of fileserver.ps1 against a live stub
+# backend. It lifts the function via the AST rather than reimplementing it:
+# a test that reimplements what it tests proves nothing about the shipped code.
+#
+#   pwsh -NoProfile -File test-search-seam.ps1
+#
+# Asserts the four things the seam has to get right, including the default,
+# because the whole promise is that an install with nothing configured does not
+# move.
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$cond, [string]$detail = '') {
+    if ($cond) { Write-Host "  PASS  $name" }
+    else { $script:fail++; Write-Host "  FAIL  $name  $detail" }
+}
+
+# --- lift the real function ---------------------------------------------------
+$errs = $null; $toks = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    (Resolve-Path "$PSScriptRoot/fileserver.ps1").Path, [ref]$toks, [ref]$errs)
+if ($errs) { throw "fileserver.ps1 does not parse: $($errs.Count) error(s)" }
+$fn = $ast.FindAll({ param($n)
+    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $n.Name -eq 'Handle-Search' }, $true) | Select-Object -First 1
+if (-not $fn) { throw 'Handle-Search not found — it moved or was renamed' }
+Invoke-Expression $fn.Extent.Text
+
+# The two response helpers, capturing instead of writing to a socket.
+$script:Captured = $null
+function Write-Json { param($Response, [int]$Status, $Object)
+    $script:Captured = @{ status = $Status; body = ($Object | ConvertTo-Json -Depth 8 -Compress) } }
+function Write-Text { param($Response, [int]$Status, [string]$ContentType, [string]$Body)
+    $script:Captured = @{ status = $Status; body = $Body } }
+
+function New-Req([string]$json, [string]$auth = $null) {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    $h = @{}
+    if ($auth) { $h['Authorization'] = $auth }
+    [pscustomobject]@{ InputStream = (New-Object System.IO.MemoryStream(,$bytes)); Headers = $h }
+}
+
+# --- a stub backend, so the http branch is exercised for real ------------------
+$listener = New-Object System.Net.HttpListener
+$port = 18731
+$listener.Prefixes.Add("http://127.0.0.1:$port/")
+$listener.Start()
+$script:LastPayload = $null
+$job = Start-ThreadJob -ScriptBlock {
+    param($l)
+    $ctx = $l.GetContext()
+    $sr = New-Object System.IO.StreamReader($ctx.Request.InputStream)
+    $received = $sr.ReadToEnd(); $sr.Close()
+    # `snippet`, deliberately: the field-name fallback is the half that fails silently.
+    $out = '{"results":[{"title":"T","url":"http://e.example","snippet":"S"}]}'
+    $b = [System.Text.Encoding]::UTF8.GetBytes($out)
+    $ctx.Response.ContentLength64 = $b.Length
+    $ctx.Response.OutputStream.Write($b, 0, $b.Length)
+    $ctx.Response.Close()
+    $received
+} -ArgumentList $listener
+
+try {
+    # 1. DEFAULT: nothing configured -> Ollama, unchanged.
+    $env:SEARCH_PROVIDER = $null; $env:SEARCH_URL = $null
+    $script:Captured = $null
+    Handle-Search -Request (New-Req '{"query":"x"}') -Response $null -SubPath '/web_search'
+    # No key and no network in CI, so this ends in a 502 from the ollama call --
+    # what matters is that it TRIED Ollama rather than the http branch.
+    Check 'default with nothing set still goes to Ollama' `
+        ($script:Captured.status -eq 502 -and $script:Captured.body -notmatch 'SEARCH_URL') `
+        $script:Captured.body
+
+    # 2. SEARCH_PROVIDER=http with no SEARCH_URL is an ERROR, never a silent fallback.
+    $env:SEARCH_PROVIDER = 'http'; $env:SEARCH_URL = $null
+    $script:Captured = $null
+    Handle-Search -Request (New-Req '{"query":"x"}') -Response $null -SubPath '/web_search'
+    Check 'explicit http with no SEARCH_URL reports it' `
+        ($script:Captured.status -eq 502 -and $script:Captured.body -match 'SEARCH_URL') `
+        $script:Captured.body
+
+    # 3. SEARCH_URL set, provider auto -> the http branch, no key needed.
+    $env:SEARCH_PROVIDER = $null; $env:SEARCH_URL = "http://127.0.0.1:$port/search"
+    $script:Captured = $null
+    Handle-Search -Request (New-Req '{"query":"goblins","max_results":3}') -Response $null -SubPath '/web_search'
+    Check 'auto + SEARCH_URL uses the http backend' ($script:Captured.status -eq 200) $script:Captured.body
+    $res = $script:Captured.body | ConvertFrom-Json
+    Check 'results come back as a NON-EMPTY list' `
+        (@($res.results).Count -eq 1) $script:Captured.body
+    Check 'a `snippet` field is read as content' `
+        ($res.results[0].content -eq 'S') "content=$($res.results[0].content)"
+
+    $sent = Receive-Job $job -Wait
+    Check 'the backend is asked in the documented shape' `
+        ($sent -match '"query"' -and $sent -match '"max_results"') $sent
+
+    # 4. Pinning ollama beats SEARCH_URL being set.
+    $env:SEARCH_PROVIDER = 'ollama'
+    $script:Captured = $null
+    Handle-Search -Request (New-Req '{"query":"x"}') -Response $null -SubPath '/web_search'
+    Check 'SEARCH_PROVIDER=ollama overrides a set SEARCH_URL' `
+        ($script:Captured.status -eq 502 -and $script:Captured.body -notmatch 'SEARCH_URL') `
+        $script:Captured.body
+}
+finally {
+    $listener.Stop(); $listener.Close()
+    Remove-Job $job -Force -ErrorAction SilentlyContinue
+    $env:SEARCH_PROVIDER = $null; $env:SEARCH_URL = $null
+}
+
+Write-Host ""
+if ($fail -eq 0) { Write-Host 'PASSED' } else { Write-Host "FAILED ($fail)" }
+exit $fail


### PR DESCRIPTION
`/search` is hardcoded to `ollama.com` and forwards the caller's `Authorization`, so web search only works for someone who has an Ollama account and has pasted a key into settings. Everyone else gets an upstream 401, which surfaces as **"search is broken"** rather than "you need an account nobody asked you for".

### The default does not move

With `SEARCH_URL` unset this is the same request to the same host with the same header, byte for byte. No existing install changes.

Set `SEARCH_URL` and search goes to whatever you run — a local SearxNG, your own service — with **no key unless yours needs one**. Point it at anything that accepts `{"query","max_results"}` and returns `{"results":[{title,url,content}]}`.

`SEARCH_PROVIDER` (`auto` | `ollama` | `http`) pins the choice for the two cases `auto` can't serve: keeping Ollama even with `SEARCH_URL` set, and treating a missing `SEARCH_URL` as an **error** rather than a quiet fallback — which is what you want once a self-hosted backend is the thing you rely on.

It deliberately does **not** implement search. A hand-rolled scraper goes stale silently: it returns an empty list rather than an error, so the UI says "found nothing" for as long as nobody checks.

### This replaces the earlier version of this PR

The first version extracted the proxy into its own script on its own port. **1.6 removed exactly that shape, and for a good reason** — one fewer process, one fewer port, no encoded payload, and the strongest malware signal in the project gone. Re-adding a separate proxy to get the seam would have undone that work. The seam belongs where `/search` now lives, so it's ~85 lines inside `Handle-Search`.

### The test

`test-search-seam.ps1` drives the **real** `Handle-Search`, lifted out of the file via the AST rather than reimplemented — a test that reimplements what it tests proves nothing about the shipped code. It runs a live stub backend and asserts the default still goes to Ollama, an explicit `http` with no `SEARCH_URL` reports it, and `snippet`/`description` are read as content (SearxNG says `content`, most engines say `snippet`).

Two of those assertions earned their place by failing first:

- a single result must still serialise as a **list** — `ConvertTo-Json` unwraps a one-element array, and the client iterates;
- a backend that omits `Content-Type` makes `Invoke-WebRequest` hand back **bytes**, and piping those to `ConvertFrom-Json` yields no `results` rather than an error — so search returns empty and reads as "found nothing" instead of "misread the reply".

Run it with `pwsh -NoProfile -File test-search-seam.ps1`.
