### PR TITLE
Fix orphaned Windows background processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ active-model.json
 
 .gobbonet-port
 .gobbonet-runtime-*.state
+.gobbonet-runtime-*.state.llm-owned

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ active-model.json
 .embed-launch.cmd
 
 .gobbonet-port
+.gobbonet-runtime-*.state

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -157,14 +157,40 @@ launch.bat
 
 ---
 
+## Closing the launcher leaves GobboNet processes running
+
+The Windows launcher starts the chat model, embedding model, search proxy and
+file server as detached background processes. A runtime watchdog now records
+which of those services were started by the current launcher invocation and
+stops only those owned processes when that launcher exits.
+
+Pre-existing services are intentionally not claimed. In particular, an Ollama
+instance that was already running before GobboNet is left untouched.
+
+After closing GobboNet, give the watchdog a few seconds and inspect the usual
+ports if anything appears to remain:
+
+```powershell
+Get-NetTCPConnection -State Listen |
+    Where-Object LocalPort -in 9066,11434,11435,11436,11437 |
+    Sort-Object LocalPort
+```
+
+`runtime-watchdog.log` records the launcher PID, ownership flags, each process
+stopped during cleanup, and the final `cleanup complete` marker. If cleanup did
+not run, include that log in the bug report.
+
+---
+
 ## The model will not load
 
 The launcher stops and shows `llama-server.log`. Two common causes:
 
 - **Not enough VRAM.** Pick a smaller model or a heavier quantisation.
-- **Stale server.** Closing the window without stopping the servers can
-  leave `llama-server.exe` holding the port. Check with
-  `netstat -ano | findstr "11437 11435 11436 9066"` and end those PIDs.
+- **Stale server.** An older GobboNet build, a crashed watchdog, or an
+  abnormal process termination can leave `llama-server.exe` holding the port.
+  Check with `netstat -ano | findstr "11437 11435 11436 9066"` and end those
+  PIDs if necessary.
 
 If a model downloaded but never loads, check for a leftover `.part` file in
 `models\` — that is an aborted download and is safe to delete.
@@ -198,8 +224,9 @@ the gaps, and nothing here will stop you trying.
 Include these in a bug report and it can usually be answered in one reply:
 
 1. `fileserver.log` (whole file)
-2. Whether launch.bat printed **"No working PowerShell found"**
-3. Whether it printed **`[OK] Search proxy on :11435`** — that line proves a
+2. `runtime-watchdog.log` if the problem involves shutdown or stale processes
+3. Whether launch.bat printed **"No working PowerShell found"**
+4. Whether it printed **`[OK] Search proxy on :11435`** — that line proves a
    PowerShell HTTP listener bound successfully minutes earlier, which rules
    out a whole class of theories
-4. Output of `netsh interface ipv4 show excludedportrange protocol=tcp`
+5. Output of `netsh interface ipv4 show excludedportrange protocol=tcp`

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -167,14 +167,17 @@ stops only those owned processes when that launcher exits.
 Pre-existing services are intentionally not claimed. In particular, an Ollama
 instance that was already running before GobboNet is left untouched.
 
-After closing GobboNet, give the watchdog a few seconds and inspect the usual
-ports if anything appears to remain:
+After closing GobboNet, give the watchdog a few seconds and inspect the
+GobboNet-owned ports if anything appears to remain:
 
 ```powershell
 Get-NetTCPConnection -State Listen |
-    Where-Object LocalPort -in 9066,11434,11435,11436,11437 |
+    Where-Object LocalPort -in 9066,11435,11436,11437 |
     Sort-Object LocalPort
 ```
+
+If Ollama was already running, its listener on `11434` should remain after
+GobboNet exits; the watchdog deliberately does not own or stop it.
 
 `runtime-watchdog.log` records the launcher PID, ownership flags, each process
 stopped during cleanup, and the final `cleanup complete` marker. If cleanup did

--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -170,6 +170,10 @@ Read-PerfOverrides
 $LogFile      = Get-EnvOrDefault 'GEMMA_LOG_FILE'       (Join-Path $Root 'llama-server.log')
 $LaunchScript = Get-EnvOrDefault 'GEMMA_LAUNCH_SCRIPT'  (Join-Path $Root '.llama-launch.cmd')
 $RuntimeState = Get-EnvOrDefault 'GOBBONET_RUNTIME_STATE' ''
+$LlmOwnershipMarker = ''
+if (-not [string]::IsNullOrWhiteSpace($RuntimeState)) {
+    $LlmOwnershipMarker = $RuntimeState + '.llm-owned'
+}
 
 $StatePath    = Join-Path $Root '.gobbonet-state.json'
 $SwapLock     = Join-Path $Root '.swap-in-progress'
@@ -177,30 +181,18 @@ $SwapStatus   = Join-Path $Root '.swap-status.json'
 $ModelsListJs = Join-Path $Root 'models-list.json'
 $ActiveJson   = Join-Path $Root 'active-model.json'
 
-# If launch.bat is supervising this file server, keep the launcher's ownership
-# state accurate when a hot-swap creates a replacement chat llama-server.
-# Standalone fileserver.ps1 runs simply leave RuntimeState empty and no-op.
-function Save-LlmRuntimeOwnership {
-    if ([string]::IsNullOrWhiteSpace($RuntimeState)) { return }
-    if (-not (Test-Path -LiteralPath $RuntimeState)) { return }
+# launch.bat is the sole writer of the shared runtime state file. If a hot-swap
+# replaces a pre-existing chat server, fileserver.ps1 only needs to promote LLM
+# ownership to true. Record that monotonic fact in a separate marker instead of
+# doing a competing read-modify-write of the launcher's state file.
+# Standalone fileserver.ps1 runs simply leave LlmOwnershipMarker empty and no-op.
+function Mark-LlmRuntimeOwnership {
+    if ([string]::IsNullOrWhiteSpace($LlmOwnershipMarker)) { return }
 
     try {
-        $lines = @(Get-Content -LiteralPath $RuntimeState -ErrorAction Stop)
-        $found = $false
-        for ($i = 0; $i -lt $lines.Count; $i++) {
-            if ($lines[$i] -match '^OWN_LLM=(0|1)$') {
-                $lines[$i] = 'OWN_LLM=1'
-                $found = $true
-                break
-            }
-        }
-        if (-not $found) { $lines += 'OWN_LLM=1' }
-
-        $tmp = $RuntimeState + '.fileserver.tmp'
-        [IO.File]::WriteAllLines($tmp, [string[]]$lines, [Text.Encoding]::ASCII)
-        Move-Item -LiteralPath $tmp -Destination $RuntimeState -Force
+        [IO.File]::WriteAllText($LlmOwnershipMarker, '1', [Text.Encoding]::ASCII)
     } catch {
-        Write-Host ("[runtime] could not update launcher ownership state: {0}" -f $_.Exception.Message)
+        Write-Host ("[runtime] could not mark launcher LLM ownership: {0}" -f $_.Exception.Message)
     }
 }
 
@@ -1678,7 +1670,9 @@ function Handle-SwapModel {
         # a fresh window with its own console host and detaches cleanly,
         # which is the same recipe launch.bat uses at boot.
         $startCmd = ('/c start "llama-server" /min "{0}"' -f $LaunchScript)
-        Save-LlmRuntimeOwnership
+        # Mark ownership before dispatch so any replacement started by this
+        # swap is classified as launcher-owned by the watchdog.
+        Mark-LlmRuntimeOwnership
         Start-Process -FilePath 'cmd.exe' `
                       -ArgumentList $startCmd `
                       -WindowStyle Hidden `

--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -169,12 +169,40 @@ function Read-PerfOverrides {
 Read-PerfOverrides
 $LogFile      = Get-EnvOrDefault 'GEMMA_LOG_FILE'       (Join-Path $Root 'llama-server.log')
 $LaunchScript = Get-EnvOrDefault 'GEMMA_LAUNCH_SCRIPT'  (Join-Path $Root '.llama-launch.cmd')
+$RuntimeState = Get-EnvOrDefault 'GOBBONET_RUNTIME_STATE' ''
 
 $StatePath    = Join-Path $Root '.gobbonet-state.json'
 $SwapLock     = Join-Path $Root '.swap-in-progress'
 $SwapStatus   = Join-Path $Root '.swap-status.json'
 $ModelsListJs = Join-Path $Root 'models-list.json'
 $ActiveJson   = Join-Path $Root 'active-model.json'
+
+# If launch.bat is supervising this file server, keep the launcher's ownership
+# state accurate when a hot-swap creates a replacement chat llama-server.
+# Standalone fileserver.ps1 runs simply leave RuntimeState empty and no-op.
+function Save-LlmRuntimeOwnership {
+    if ([string]::IsNullOrWhiteSpace($RuntimeState)) { return }
+    if (-not (Test-Path -LiteralPath $RuntimeState)) { return }
+
+    try {
+        $lines = @(Get-Content -LiteralPath $RuntimeState -ErrorAction Stop)
+        $found = $false
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match '^OWN_LLM=(0|1)$') {
+                $lines[$i] = 'OWN_LLM=1'
+                $found = $true
+                break
+            }
+        }
+        if (-not $found) { $lines += 'OWN_LLM=1' }
+
+        $tmp = $RuntimeState + '.fileserver.tmp'
+        [IO.File]::WriteAllLines($tmp, [string[]]$lines, [Text.Encoding]::ASCII)
+        Move-Item -LiteralPath $tmp -Destination $RuntimeState -Force
+    } catch {
+        Write-Host ("[runtime] could not update launcher ownership state: {0}" -f $_.Exception.Message)
+    }
+}
 
 # Detached-generation spool directory (see "Generation jobs" section). Each
 # job is three small files: <id>.sse (raw upstream byte stream), <id>.json
@@ -1650,6 +1678,7 @@ function Handle-SwapModel {
         # a fresh window with its own console host and detaches cleanly,
         # which is the same recipe launch.bat uses at boot.
         $startCmd = ('/c start "llama-server" /min "{0}"' -f $LaunchScript)
+        Save-LlmRuntimeOwnership
         Start-Process -FilePath 'cmd.exe' `
                       -ArgumentList $startCmd `
                       -WindowStyle Hidden `

--- a/launch.bat
+++ b/launch.bat
@@ -431,6 +431,10 @@ set "OWN_SEARCH=0"
 set "OWN_WEB=0"
 set "RUNTIME_STATE="
 if defined LAUNCHER_PID set "RUNTIME_STATE=%~dp0.gobbonet-runtime-!LAUNCHER_PID!.state"
+:: A hot-swap may leave a monotonic LLM-ownership marker if the watchdog was
+:: interrupted before cleanup. PID reuse is possible, so clear any stale marker
+:: before this launcher instance begins recording ownership.
+if defined RUNTIME_STATE if exist "!RUNTIME_STATE!.llm-owned" del /f /q "!RUNTIME_STATE!.llm-owned" >nul 2>&1
 call :write_runtime_state
 call :start_runtime_watchdog
 
@@ -2147,7 +2151,23 @@ if not defined RUNTIME_STATE exit /b
     echo OWN_SEARCH=!OWN_SEARCH!
     echo OWN_WEB=!OWN_WEB!
 )
-move /y "!RUNTIME_STATE!.tmp" "!RUNTIME_STATE!" >nul 2>&1
+:: launch.bat is the sole writer of the state file. Keep the atomic replace,
+:: but retry transient Windows/antivirus locks instead of silently losing an
+:: ownership update that the watchdog will need after this process exits.
+set "RUNTIME_STATE_UPDATED="
+for /l %%R in (1,1,5) do if not defined RUNTIME_STATE_UPDATED (
+    move /y "!RUNTIME_STATE!.tmp" "!RUNTIME_STATE!" >nul 2>&1
+    if not errorlevel 1 (
+        set "RUNTIME_STATE_UPDATED=1"
+    ) else if %%R lss 5 (
+        timeout /t 1 /nobreak >nul 2>&1
+    )
+)
+if not defined RUNTIME_STATE_UPDATED (
+    echo  [*] Could not update runtime ownership state; automatic cleanup may be incomplete.
+    del /f /q "!RUNTIME_STATE!.tmp" >nul 2>&1
+)
+set "RUNTIME_STATE_UPDATED="
 exit /b
 
 :start_runtime_watchdog

--- a/launch.bat
+++ b/launch.bat
@@ -1,19 +1,28 @@
 @echo off
 :: ---------------------------------------------------------------
-:: KEEP-OPEN GUARD -- this window can NEVER silently vanish.
-:: If anything fails (a crash, a blocked tool, a bad path, even a
-:: stray syntax error), the message stays on screen instead of the
-:: window closing too fast to read. We relaunch ourselves once
-:: inside "cmd /k", which holds the window open at a prompt no
-:: matter how the script exits. The env var is inherited by the
-:: relaunch, so this happens exactly once and then never again.
+:: KEEP-OPEN / LIFECYCLE GUARD
+:: Relaunch once in a dedicated cmd /c process. cmd /k leaves that
+:: shell alive at a prompt after the batch itself ends, so detached
+:: services have no reliable process lifetime to follow. cmd /c gives
+:: the launcher a real boundary that ends with the batch invocation.
 :: ---------------------------------------------------------------
 if not defined GOBBONET_KEEPOPEN (
     set "GOBBONET_KEEPOPEN=1"
-    cmd /k ""%~f0" %*"
+    cmd /c ""%~f0" %*"
+    set "GOBBONET_KEEPOPEN="
     exit /b
 )
 setlocal EnableDelayedExpansion
+
+:: Find the dedicated cmd.exe that is actually executing launch.bat.
+:: FOR /F runs backtick commands through a short-lived helper cmd.exe,
+:: so asking PowerShell for its immediate parent selects the wrong PID.
+:: Walk ancestors until the command line contains this script path.
+set "LAUNCHER_PID="
+set "GN_LAUNCH_SCRIPT=%~f0"
+for /f "usebackq delims=" %%P in (`powershell -NoProfile -Command "$cur=$PID; for($i=0;$i -lt 10;$i++){ $p=Get-CimInstance Win32_Process -Filter ('ProcessId=' + $cur) -ErrorAction SilentlyContinue; if($null -eq $p){break}; if($p.Name -ieq 'cmd.exe' -and ([string]$p.CommandLine).IndexOf($env:GN_LAUNCH_SCRIPT,[StringComparison]::OrdinalIgnoreCase) -ge 0){ [Console]::Write($p.ProcessId); break }; $cur=$p.ParentProcessId }" 2^>nul`) do set "LAUNCHER_PID=%%P"
+set "GN_LAUNCH_SCRIPT="
+
 title Gobbonet - Local AI Chat [llama.cpp]
 color 0A
 
@@ -412,6 +421,18 @@ set "EMBED_MODEL_URL=https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/
 set "EMBED_PIN_SHA256="
 set "EMBED_LOG_FILE=%~dp0embed-server.log"
 set "EMBED_LAUNCH_SCRIPT=%~dp0.embed-launch.cmd"
+
+:: Runtime ownership flags. The watchdog only stops services that this
+:: launcher invocation actually spawned. Compatible pre-existing services
+:: are deliberately left alone.
+set "OWN_LLM=0"
+set "OWN_EMBED=0"
+set "OWN_SEARCH=0"
+set "OWN_WEB=0"
+set "RUNTIME_STATE="
+if defined LAUNCHER_PID set "RUNTIME_STATE=%~dp0.gobbonet-runtime-!LAUNCHER_PID!.state"
+call :write_runtime_state
+call :start_runtime_watchdog
 
 goto :main
 
@@ -1513,6 +1534,8 @@ if not "!MODEL_CHAT_TEMPLATE_FILE!"=="" (
     echo "!SERVER_EXE!" --model "!GGUF_PATH!" --port !SERVER_PORT! --host 127.0.0.1 --ctx-size !CTX_SIZE! --n-gpu-layers !GPU_LAYERS! --cache-type-k !KV_CACHE_TYPE! --cache-type-v !KV_CACHE_TYPE! --parallel 1 !JINJA_FLAG! !CHAT_TEMPLATE_FLAG! --reasoning-format auto ^> "!LOG_FILE!" 2^>^&1
 )
 
+set "OWN_LLM=1"
+call :write_runtime_state
 start /min "llama-server" "!LAUNCH_SCRIPT!"
 
 echo  [..] Waiting for server to load model...
@@ -1695,6 +1718,8 @@ if errorlevel 1 (
     echo "!SERVER_EXE!" --model "!EMBED_PATH!" --port !EMBED_PORT! --host 127.0.0.1 --embeddings --pooling mean --ctx-size !EMBED_CTX! --batch-size !EMBED_CTX! --ubatch-size !EMBED_CTX! --n-gpu-layers !EMBED_GPU_LAYERS! ^> "!EMBED_LOG_FILE!" 2^>^&1
 )
 echo  [..] Starting embedding server on :!EMBED_PORT! ^(CPU^)...
+set "OWN_EMBED=1"
+call :write_runtime_state
 start /min "embed-server" "!EMBED_LAUNCH_SCRIPT!"
 
 set "ERETRIES=0"
@@ -1729,6 +1754,8 @@ if not errorlevel 1 (
 )
 
 echo  [..] Starting search proxy on :!SEARCH_PORT!...
+set "OWN_SEARCH=1"
+call :write_runtime_state
 start /min powershell -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand "JABFAHIAcgBvAHIAQQBjAHQAaQBvAG4AUAByAGUAZgBlAHIAZQBuAGMAZQAgAD0AIAAnAFMAaQBsAGUAbgB0AGwAeQBDAG8AbgB0AGkAbgB1AGUAJwAKAFsATgBlAHQALgBTAGUAcgB2AGkAYwBlAFAAbwBpAG4AdABNAGEAbgBhAGcAZQByAF0AOgA6AFMAZQBjAHUAcgBpAHQAeQBQAHIAbwB0AG8AYwBvAGwAIAA9ACAAWwBOAGUAdAAuAFMAZQBjAHUAcgBpAHQAeQBQAHIAbwB0AG8AYwBvAGwAVAB5AHAAZQBdADoAOgBUAGwAcwAxADIACgAkAGwAaQBzAHQAZQBuAGUAcgAgAD0AIABOAGUAdwAtAE8AYgBqAGUAYwB0ACAAUwB5AHMAdABlAG0ALgBOAGUAdAAuAEgAdAB0AHAATABpAHMAdABlAG4AZQByAAoAJABsAGkAcwB0AGUAbgBlAHIALgBQAHIAZQBmAGkAeABlAHMALgBBAGQAZAAoACcAaAB0AHQAcAA6AC8ALwAxADIANwAuADAALgAwAC4AMQA6ADEAMQA0ADMANQAvACcAKQAKAHQAcgB5ACAAewAgACQAbABpAHMAdABlAG4AZQByAC4AUwB0AGEAcgB0ACgAKQAgAH0AIABjAGEAdABjAGgAIAB7ACAAZQB4AGkAdAAgADEAIAB9AAoAdwBoAGkAbABlACAAKAAkAGwAaQBzAHQAZQBuAGUAcgAuAEkAcwBMAGkAcwB0AGUAbgBpAG4AZwApACAAewAKACAAIAAkAGMAdAB4ACAAPQAgACQAbABpAHMAdABlAG4AZQByAC4ARwBlAHQAQwBvAG4AdABlAHgAdAAoACkACgAgACAAJAByAGUAcwBwACAAPQAgACQAYwB0AHgALgBSAGUAcwBwAG8AbgBzAGUACgAgACAAJAByAGUAcwBwAC4AQQBkAGQASABlAGEAZABlAHIAKAAnAEEAYwBjAGUAcwBzAC0AQwBvAG4AdAByAG8AbAAtAEEAbABsAG8AdwAtAE8AcgBpAGcAaQBuACcALAAgACcAKgAnACkACgAgACAAJAByAGUAcwBwAC4AQQBkAGQASABlAGEAZABlAHIAKAAnAEEAYwBjAGUAcwBzAC0AQwBvAG4AdAByAG8AbAAtAEEAbABsAG8AdwAtAE0AZQB0AGgAbwBkAHMAJwAsACAAJwBQAE8AUwBUACwAIABHAEUAVAAsACAATwBQAFQASQBPAE4AUwAnACkACgAgACAAJAByAGUAcwBwAC4AQQBkAGQASABlAGEAZABlAHIAKAAnAEEAYwBjAGUAcwBzAC0AQwBvAG4AdAByAG8AbAAtAEEAbABsAG8AdwAtAEgAZQBhAGQAZQByAHMAJwAsACAAJwBDAG8AbgB0AGUAbgB0AC0AVAB5AHAAZQAsACAAQQB1AHQAaABvAHIAaQB6AGEAdABpAG8AbgAnACkACgAgACAAaQBmACAAKAAkAGMAdAB4AC4AUgBlAHEAdQBlAHMAdAAuAEgAdAB0AHAATQBlAHQAaABvAGQAIAAtAGUAcQAgACcATwBQAFQASQBPAE4AUwAnACkAIAB7AAoAIAAgACAAIAAkAHIAZQBzAHAALgBTAHQAYQB0AHUAcwBDAG8AZABlACAAPQAgADIAMAA0ADsAIAAkAHIAZQBzAHAALgBDAGwAbwBzAGUAKAApADsAIABjAG8AbgB0AGkAbgB1AGUACgAgACAAfQAKACAAIAAkAHAAYQB0AGgAIAA9ACAAJABjAHQAeAAuAFIAZQBxAHUAZQBzAHQALgBVAHIAbAAuAEEAYgBzAG8AbAB1AHQAZQBQAGEAdABoAAoAIAAgAGkAZgAgACgAJABwAGEAdABoACAALQBlAHEAIAAnAC8AaABlAGEAbAB0AGgAJwApACAAewAKACAAIAAgACAAJAByAGUAcwBwAC4AUwB0AGEAdAB1AHMAQwBvAGQAZQAgAD0AIAAyADAAMAAKACAAIAAgACAAJABiACAAPQAgAFsAVABlAHgAdAAuAEUAbgBjAG8AZABpAG4AZwBdADoAOgBVAFQARgA4AC4ARwBlAHQAQgB5AHQAZQBzACgAJwB7ACIAcwB0AGEAdAB1AHMAIgA6ACIAbwBrACIAfQAnACkACgAgACAAIAAgACQAcgBlAHMAcAAuAE8AdQB0AHAAdQB0AFMAdAByAGUAYQBtAC4AVwByAGkAdABlACgAJABiACwAIAAwACwAIAAkAGIALgBMAGUAbgBnAHQAaAApADsAIAAkAHIAZQBzAHAALgBDAGwAbwBzAGUAKAApADsAIABjAG8AbgB0AGkAbgB1AGUACgAgACAAfQAKACAAIAB0AHIAeQAgAHsACgAgACAAIAAgACQAcwByACAAPQAgAE4AZQB3AC0ATwBiAGoAZQBjAHQAIABJAE8ALgBTAHQAcgBlAGEAbQBSAGUAYQBkAGUAcgAoACQAYwB0AHgALgBSAGUAcQB1AGUAcwB0AC4ASQBuAHAAdQB0AFMAdAByAGUAYQBtACkACgAgACAAIAAgACQAYgBvAGQAeQAgAD0AIAAkAHMAcgAuAFIAZQBhAGQAVABvAEUAbgBkACgAKQA7ACAAJABzAHIALgBDAGwAbwBzAGUAKAApAAoAIAAgACAAIAAkAHQAYQByAGcAZQB0AFUAcgBsACAAPQAgACcAaAB0AHQAcABzADoALwAvAG8AbABsAGEAbQBhAC4AYwBvAG0ALwBhAHAAaQAnACAAKwAgACQAcABhAHQAaAAKACAAIAAgACAAJABoAGUAYQBkAGUAcgBzACAAPQAgAEAAewAgACcAQwBvAG4AdABlAG4AdAAtAFQAeQBwAGUAJwAgAD0AIAAnAGEAcABwAGwAaQBjAGEAdABpAG8AbgAvAGoAcwBvAG4AJwAgAH0ACgAgACAAIAAgACQAYQB1AHQAaAAgAD0AIAAkAGMAdAB4AC4AUgBlAHEAdQBlAHMAdAAuAEgAZQBhAGQAZQByAHMAWwAnAEEAdQB0AGgAbwByAGkAegBhAHQAaQBvAG4AJwBdAAoAIAAgACAAIABpAGYAIAAoACQAYQB1AHQAaAApACAAewAgACQAaABlAGEAZABlAHIAcwBbACcAQQB1AHQAaABvAHIAaQB6AGEAdABpAG8AbgAnAF0AIAA9ACAAJABhAHUAdABoACAAfQAKACAAIAAgACAAJAB3AHIAIAA9ACAASQBuAHYAbwBrAGUALQBXAGUAYgBSAGUAcQB1AGUAcwB0ACAALQBVAHIAaQAgACQAdABhAHIAZwBlAHQAVQByAGwAIAAtAE0AZQB0AGgAbwBkACAAUABPAFMAVAAgAC0AQgBvAGQAeQAgACQAYgBvAGQAeQAgAC0ASABlAGEAZABlAHIAcwAgACQAaABlAGEAZABlAHIAcwAgAC0AVQBzAGUAQgBhAHMAaQBjAFAAYQByAHMAaQBuAGcAIAAtAFQAaQBtAGUAbwB1AHQAUwBlAGMAIAAzADAACgAgACAAIAAgACQAcgBlAHMAcAAuAEMAbwBuAHQAZQBuAHQAVAB5AHAAZQAgAD0AIAAnAGEAcABwAGwAaQBjAGEAdABpAG8AbgAvAGoAcwBvAG4AJwAKACAAIAAgACAAJABvAGIAIAA9ACAAWwBUAGUAeAB0AC4ARQBuAGMAbwBkAGkAbgBnAF0AOgA6AFUAVABGADgALgBHAGUAdABCAHkAdABlAHMAKAAkAHcAcgAuAEMAbwBuAHQAZQBuAHQAKQAKACAAIAAgACAAJAByAGUAcwBwAC4ATwB1AHQAcAB1AHQAUwB0AHIAZQBhAG0ALgBXAHIAaQB0AGUAKAAkAG8AYgAsACAAMAAsACAAJABvAGIALgBMAGUAbgBnAHQAaAApAAoAIAAgAH0AIABjAGEAdABjAGgAIAB7AAoAIAAgACAAIAAkAHIAZQBzAHAALgBTAHQAYQB0AHUAcwBDAG8AZABlACAAPQAgADUAMAAyAAoAIAAgACAAIAAkAGUAbQAgAD0AIAAnAHsAIgBlAHIAcgBvAHIAIgA6ACIAcAByAG8AeAB5ADoAIAAnACAAKwAgACQAXwAuAEUAeABjAGUAcAB0AGkAbwBuAC4ATQBlAHMAcwBhAGcAZQAuAFIAZQBwAGwAYQBjAGUAKAAnACIAJwAsACcAJwApAC4AUgBlAHAAbABhAGMAZQAoACIAYAByACIALAAnACcAKQAuAFIAZQBwAGwAYQBjAGUAKAAiAGAAbgAiACwAJwAgACcAKQAgACsAIAAnACIAfQAnAAoAIAAgACAAIAAkAGUAYgAgAD0AIABbAFQAZQB4AHQALgBFAG4AYwBvAGQAaQBuAGcAXQA6ADoAVQBUAEYAOAAuAEcAZQB0AEIAeQB0AGUAcwAoACQAZQBtACkACgAgACAAIAAgACQAcgBlAHMAcAAuAE8AdQB0AHAAdQB0AFMAdAByAGUAYQBtAC4AVwByAGkAdABlACgAJABlAGIALAAgADAALAAgACQAZQBiAC4ATABlAG4AZwB0AGgAKQAKACAAIAB9AAoAIAAgACQAcgBlAHMAcAAuAEMAbABvAHMAZQAoACkACgB9AAoA"
 
 set "PRETRIES=0"
@@ -1794,6 +1821,8 @@ set "GEMMA_ACCESS_SECRET=!ACCESS_SECRET!"
 :: fileserver.ps1 resolves the port the same way, but pass it explicitly so
 :: the two can never disagree about which port this run is using.
 set "GEMMA_LISTEN_PORT=!WEB_PORT!"
+set "OWN_WEB=1"
+call :write_runtime_state
 start /min powershell -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%~dp0fileserver.ps1"
 
 set "FRETRIES=0"
@@ -1977,7 +2006,8 @@ echo   This window will minimize in 8 seconds.
 echo   It monitors server health in the background.
 echo.
 echo   To shut down: restore this window and press Ctrl+C,
-echo   or simply close it.
+echo   or simply close it. Services started by this launch are
+echo   cleaned up automatically.
 echo  ====================================================
 echo.
 
@@ -2061,6 +2091,8 @@ set "GN_KILLPORT="
 timeout /t 3 /nobreak >nul
 
 echo  [..] Restarting llama-server...
+set "OWN_LLM=1"
+call :write_runtime_state
 start /min "llama-server" "!LAUNCH_SCRIPT!"
 
 echo  [..] Waiting for server to come back up...
@@ -2107,6 +2139,37 @@ goto :monitor_loop
 :: ===============================================================
 :: UTILITY SUBROUTINES
 :: ===============================================================
+:write_runtime_state
+if not defined RUNTIME_STATE exit /b
+> "!RUNTIME_STATE!.tmp" (
+    echo OWN_LLM=!OWN_LLM!
+    echo OWN_EMBED=!OWN_EMBED!
+    echo OWN_SEARCH=!OWN_SEARCH!
+    echo OWN_WEB=!OWN_WEB!
+)
+move /y "!RUNTIME_STATE!.tmp" "!RUNTIME_STATE!" >nul 2>&1
+exit /b
+
+:start_runtime_watchdog
+if not defined LAUNCHER_PID (
+    echo  [*] Could not determine launcher PID -- automatic child cleanup disabled.
+    exit /b
+)
+if not exist "%~dp0runtime-watchdog.ps1" (
+    echo  [*] runtime-watchdog.ps1 not found -- automatic child cleanup disabled.
+    exit /b
+)
+
+set "GOBBONET_PARENT_PID=!LAUNCHER_PID!"
+set "GOBBONET_RUNTIME_STATE=!RUNTIME_STATE!"
+set "GOBBONET_ROOT=%~dp0."
+set "GOBBONET_LLM_PORT=!SERVER_PORT!"
+set "GOBBONET_EMBED_PORT=!EMBED_PORT!"
+set "GOBBONET_SEARCH_PORT=!SEARCH_PORT!"
+set "GOBBONET_WEB_PORT=!WEB_PORT!"
+start "" powershell -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%~dp0runtime-watchdog.ps1"
+exit /b
+
 :minimize_window
 powershell -NoProfile -command "try{Add-Type -Name W -Namespace C -MemberDefinition '[DllImport(\"kernel32.dll\")]public static extern IntPtr GetConsoleWindow();[DllImport(\"user32.dll\")]public static extern bool ShowWindow(IntPtr h,int c);' -EA Stop}catch{};[C.W]::ShowWindow([C.W]::GetConsoleWindow(),6)" >nul 2>&1
 exit /b

--- a/runtime-watchdog.ps1
+++ b/runtime-watchdog.ps1
@@ -1,0 +1,195 @@
+# ==============================================================================
+# runtime-watchdog.ps1 -- clean up background services owned by one launch.bat
+#
+# This variant targets current GobboNet 1.5.8:
+#   - web UI default: 9066
+#   - llama.cpp:      11437
+#   - embeddings:     11436
+#   - search proxy:   11435 (PowerShell -EncodedCommand)
+#
+# The launcher writes an ownership state file. When the dedicated launcher
+# cmd.exe exits, this watchdog stops only services that this invocation marked
+# as owned. Pre-existing compatible services are left alone.
+# ==============================================================================
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+function Env([string]$Name, $Default = '') {
+	$v = [Environment]::GetEnvironmentVariable($Name)
+	if ([string]::IsNullOrWhiteSpace($v)) { return $Default }
+	return $v
+}
+
+$ParentPid = [int](Env 'GOBBONET_PARENT_PID' '0')
+$StateFile = Env 'GOBBONET_RUNTIME_STATE'
+$Root = [IO.Path]::GetFullPath((Env 'GOBBONET_ROOT' (Split-Path -Parent $MyInvocation.MyCommand.Path))).TrimEnd('\')
+$RootPrefix = $Root + '\'
+$LlmPort = [int](Env 'GOBBONET_LLM_PORT' '11437')
+$EmbedPort = [int](Env 'GOBBONET_EMBED_PORT' '11436')
+$SearchPort = [int](Env 'GOBBONET_SEARCH_PORT' '11435')
+$WebPort = [int](Env 'GOBBONET_WEB_PORT' '9066')
+$LogFile = Join-Path $Root 'runtime-watchdog.log'
+
+function Log([string]$Text) {
+	try {
+		Add-Content -LiteralPath $LogFile `
+			-Value ('[{0:yyyy-MM-dd HH:mm:ss}] {1}' -f (Get-Date), $Text) `
+			-Encoding UTF8
+	}
+	catch {
+		Write-Debug ("Could not append to runtime-watchdog.log: {0}" -f $_.Exception.Message)
+	}
+}
+
+function Test-ParentAlive {
+	if ($ParentPid -le 0) { return $false }
+	return $null -ne (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue)
+}
+
+function Read-Ownership {
+	$o = @{ LLM = $false; EMBED = $false; SEARCH = $false; WEB = $false }
+
+	if (-not $StateFile -or -not (Test-Path -LiteralPath $StateFile)) {
+		return $o
+	}
+
+	foreach ($line in (Get-Content -LiteralPath $StateFile -ErrorAction SilentlyContinue)) {
+		if ($line -match '^OWN_(LLM|EMBED|SEARCH|WEB)=(1|0)$') {
+			$o[$Matches[1]] = ($Matches[2] -eq '1')
+		}
+	}
+
+	return $o
+}
+
+function Test-PortArgument([string]$Cmd, [int]$Port) {
+	if ([string]::IsNullOrWhiteSpace($Cmd)) { return $false }
+
+	return $Cmd -match (
+		'(?i)(?:--port\s+|--port=)' +
+		[regex]::Escape([string]$Port) +
+		'(?:\s|$)'
+	)
+}
+
+function Test-CommandInRoot([string]$Cmd) {
+	if ([string]::IsNullOrWhiteSpace($Cmd)) { return $false }
+	return $Cmd.IndexOf($RootPrefix, [StringComparison]::OrdinalIgnoreCase) -ge 0
+}
+
+function Get-EncodedCommandText([string]$Cmd) {
+	if ([string]::IsNullOrWhiteSpace($Cmd)) { return $null }
+
+	# Windows PowerShell -EncodedCommand is UTF-16LE base64.
+	if ($Cmd -notmatch '(?i)(?:^|\s)-(?:EncodedCommand|enc)\s+"?([A-Za-z0-9+/=]+)"?(?:\s|$)') {
+		return $null
+	}
+
+	try {
+		$bytes = [Convert]::FromBase64String($Matches[1])
+		return [Text.Encoding]::Unicode.GetString($bytes)
+	}
+	catch {
+		return $null
+	}
+}
+
+function Test-GobboSearchProxy([string]$Cmd) {
+	$decoded = Get-EncodedCommandText $Cmd
+	if ([string]::IsNullOrWhiteSpace($decoded)) { return $false }
+
+	# The 1.5.8 proxy is launched as PowerShell -EncodedCommand, so its normal
+	# process command line does not contain the GobboNet project path. Identify
+	# the script by several independent markers instead of relying on SEARCH_PORT:
+	# 1.5.8 still hardcodes 11435 inside the encoded script even when
+	# GEMMA_SEARCH_PORT is overridden by launch.bat.
+	return (
+		$decoded.IndexOf('System.Net.HttpListener', [StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+		$decoded -match 'http://127\.0\.0\.1:\d+/' -and
+		$decoded.IndexOf('ollama.com/api', [StringComparison]::OrdinalIgnoreCase) -ge 0 -and
+		$decoded.IndexOf('Access-Control-Allow-Origin', [StringComparison]::OrdinalIgnoreCase) -ge 0
+	)
+}
+
+if ($ParentPid -le 0) { exit 0 }
+
+# Snapshot processes before GobboNet starts its detached services. Ownership
+# flags are the primary guard; this baseline is defense-in-depth against a
+# failed spawn leaving OWN_* set to 1, and against accidentally matching a
+# compatible process that was already running before this launcher instance.
+$BaselineProcesses = @{}
+foreach ($p in @(Get-CimInstance Win32_Process)) {
+	$BaselineProcesses[[int]$p.ProcessId] = [string]$p.CreationDate
+}
+
+function Test-PreexistingProcess($Process) {
+	$pidValue = [int]$Process.ProcessId
+	if (-not $BaselineProcesses.ContainsKey($pidValue)) { return $false }
+	return $BaselineProcesses[$pidValue] -eq [string]$Process.CreationDate
+}
+
+Log ("watching launcher pid={0}; llm={1} embed={2} search={3} web={4}; baseline={5}" -f `
+		$ParentPid, $LlmPort, $EmbedPort, $SearchPort, $WebPort, $BaselineProcesses.Count)
+
+while (Test-ParentAlive) {
+	Start-Sleep -Seconds 2
+}
+
+$own = Read-Ownership
+Log ("launcher exited; ownership llm={0} embed={1} search={2} web={3}" -f `
+		$own.LLM, $own.EMBED, $own.SEARCH, $own.WEB)
+
+# Query command lines once. Cleanup is based on ownership + service identity,
+# never on a port alone, so unrelated apps (especially Ollama) are left alone.
+$procs = @(Get-CimInstance Win32_Process)
+
+foreach ($p in $procs) {
+	# Never touch a process that already existed when this watchdog started,
+	# even if later ownership flags or identity matching would otherwise select it.
+	if (Test-PreexistingProcess $p) { continue }
+
+	$name = ([string]$p.Name).ToLowerInvariant()
+	$cmd = [string]$p.CommandLine
+	$kill = $false
+
+	if ($name -eq 'llama-server.exe') {
+		if (Test-CommandInRoot $cmd) {
+			if ($own.LLM -and (Test-PortArgument $cmd $LlmPort)) { $kill = $true }
+			if ($own.EMBED -and (Test-PortArgument $cmd $EmbedPort)) { $kill = $true }
+		}
+	}
+	elseif ($name -in @('powershell.exe', 'pwsh.exe')) {
+		# fileserver.ps1 has the project-root path in its command line.
+		if ($own.WEB -and (Test-CommandInRoot $cmd) -and $cmd -match '(?i)fileserver\.ps1') {
+			$kill = $true
+		}
+
+		# The 1.5.8 search proxy is an encoded PowerShell command and therefore
+		# has no project-root path in its process command line.
+		if ($own.SEARCH -and (Test-GobboSearchProxy $cmd)) {
+			$kill = $true
+		}
+	}
+	elseif ($name -eq 'cmd.exe') {
+		if (Test-CommandInRoot $cmd) {
+			if ($own.LLM -and $cmd -match '(?i)\.llama-launch\.cmd') { $kill = $true }
+			if ($own.EMBED -and $cmd -match '(?i)\.embed-launch\.cmd') { $kill = $true }
+		}
+	}
+
+	if ($kill) {
+		try {
+			Log ("stopping pid={0} name={1}" -f $p.ProcessId, $p.Name)
+			Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue
+		}
+		catch {
+			Write-Debug ("Could not stop PID {0}: {1}" -f $p.ProcessId, $_.Exception.Message)
+		}
+	}
+}
+
+if ($StateFile) {
+	Remove-Item -LiteralPath $StateFile -Force -ErrorAction SilentlyContinue
+}
+
+Log 'cleanup complete'

--- a/runtime-watchdog.ps1
+++ b/runtime-watchdog.ps1
@@ -22,6 +22,10 @@ function Env([string]$Name, $Default = '') {
 
 $ParentPid = [int](Env 'GOBBONET_PARENT_PID' '0')
 $StateFile = Env 'GOBBONET_RUNTIME_STATE'
+$LlmOwnershipMarker = ''
+if ($StateFile) {
+	$LlmOwnershipMarker = $StateFile + '.llm-owned'
+}
 $Root = [IO.Path]::GetFullPath((Env 'GOBBONET_ROOT' (Split-Path -Parent $MyInvocation.MyCommand.Path))).TrimEnd('\')
 $RootPrefix = $Root + '\'
 $LlmPort = [int](Env 'GOBBONET_LLM_PORT' '11437')
@@ -49,14 +53,19 @@ function Test-ParentAlive {
 function Read-Ownership {
 	$o = @{ LLM = $false; EMBED = $false; SEARCH = $false; WEB = $false }
 
-	if (-not $StateFile -or -not (Test-Path -LiteralPath $StateFile)) {
-		return $o
+	if ($StateFile -and (Test-Path -LiteralPath $StateFile)) {
+		foreach ($line in (Get-Content -LiteralPath $StateFile -ErrorAction SilentlyContinue)) {
+			if ($line -match '^OWN_(LLM|EMBED|SEARCH|WEB)=(1|0)$') {
+				$o[$Matches[1]] = ($Matches[2] -eq '1')
+			}
+		}
 	}
 
-	foreach ($line in (Get-Content -LiteralPath $StateFile -ErrorAction SilentlyContinue)) {
-		if ($line -match '^OWN_(LLM|EMBED|SEARCH|WEB)=(1|0)$') {
-			$o[$Matches[1]] = ($Matches[2] -eq '1')
-		}
+	# Hot-swaps can promote LLM ownership after launch.bat wrote the shared
+	# state. The marker is monotonic and has a single writer, so no cross-process
+	# read-modify-write is required.
+	if ($LlmOwnershipMarker -and (Test-Path -LiteralPath $LlmOwnershipMarker)) {
+		$o.LLM = $true
 	}
 
 	return $o
@@ -190,6 +199,9 @@ foreach ($p in $procs) {
 
 if ($StateFile) {
 	Remove-Item -LiteralPath $StateFile -Force -ErrorAction SilentlyContinue
+}
+if ($LlmOwnershipMarker) {
+	Remove-Item -LiteralPath $LlmOwnershipMarker -Force -ErrorAction SilentlyContinue
 }
 
 Log 'cleanup complete'


### PR DESCRIPTION
# Fix Windows launcher cleanup for orphaned background processes

## Summary

Addresses the remaining orphaned-process part of #14.

The Windows launcher starts several services as detached background processes, so closing the launcher did not reliably stop the processes it created. This change adds an explicit launcher lifetime boundary plus a runtime watchdog that cleans up only services owned by that specific launcher invocation.

The cleanup is intentionally conservative: pre-existing compatible services are not claimed or terminated, and process matching is not based on a port alone.

## What changed

* relaunch `launch.bat` inside a dedicated `cmd /c` process so there is a reliable launcher lifetime to watch;
* resolve that launcher PID and create a per-launch runtime state file;
* track ownership separately for the chat LLM, embedding server, search proxy, and web file server;
* add `runtime-watchdog.ps1`, which snapshots processes before startup, waits for the launcher to exit, then stops only owned processes that also match the expected GobboNet service identity;
* protect pre-existing processes with the startup baseline, even if they happen to match a compatible executable/port later;
* identify the encoded PowerShell search proxy by multiple script markers rather than by port alone;
* keep LLM ownership accurate when `fileserver.ps1` performs a model hot-swap and starts a replacement `llama-server`;
* ignore per-launch runtime state files in `.gitignore`;
* document shutdown troubleshooting and the watchdog log in `TROUBLESHOOTING.md`.

## Safety notes

The watchdog does **not** terminate arbitrary processes listening on GobboNet's configured ports.

Cleanup requires both launcher ownership state and service identity checks, with an additional process-baseline guard. In particular, a service such as Ollama that was already running before GobboNet is intentionally left untouched.

If launcher PID detection or the watchdog script is unavailable, startup continues with automatic cleanup disabled rather than falling back to broad process termination.

## Testing

Manually tested the branch against the Windows shutdown scenario from #14: closing the launcher cleans up GobboNet-owned background services while pre-existing services remain running.

## Context

Issue #14 covered several Windows launcher problems. The port handling and health-check portions have already been addressed upstream; this PR is focused on the remaining process-lifecycle/cleanup problem that was called out there as still unresolved.
