### PR TITLE
The password works in the installer but not the browser: launch.bat adopts an orphan holding the old salt

### DIFF
--- a/doctor.ps1
+++ b/doctor.ps1
@@ -1,0 +1,307 @@
+<#
+  GobboNet doctor -- answer "why won't it let me in" without a reinstall.
+
+  Standalone by design: no dependencies, nothing to install, no account. Drop it next to
+  launch.bat and run it. Everything it checks is local, and every check names the fix.
+
+  Usage:
+    powershell -NoProfile -ExecutionPolicy Bypass -File doctor.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -File doctor.ps1 -SelfTest
+
+  Exit codes:  0 all clear   1 a problem was found   2 could not judge
+
+  THE CHECK THIS EXISTS FOR (D-ORPHAN below). launch.bat probes the web port before it
+  spawns, and if anything answers it prints "[OK] File server already running" and reuses
+  it. But the password is handed to the server by ENVIRONMENT at spawn time, so an
+  orphaned fileserver.ps1 from an earlier run is still holding the OLD salt. Set a new
+  password and the launcher adopts the orphan, which rejects it -- and no amount of
+  deleting .gobbonet-secret, reinstalling, or disabling antivirus touches a running
+  process. Only a reboot does, which is why "I rebooted and it fixed itself" is in
+  launch.bat's own comments.
+
+  From the outside every signal is reassuring: the installer accepts the password, the
+  page loads, the login form appears. The only observable is that the password is wrong.
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 0,
+    [string]$Root = '',
+    [switch]$SelfTest
+)
+
+$script:Problems = 0
+$script:Judged = 0
+
+function Say-Ok   ($m) { Write-Host "  [ok]   $m" -ForegroundColor Green }
+function Say-Bad  ($m) { Write-Host "  [FAIL] $m" -ForegroundColor Red;    $script:Problems++ }
+function Say-Dead ($m) { Write-Host "  [????] $m" -ForegroundColor Yellow }
+function Say-Info ($m) { Write-Host "         $m" -ForegroundColor DarkGray }
+
+# ---------------------------------------------------------------------------------------
+# Pure decision functions. Kept free of I/O so -SelfTest can drive them with fixtures --
+# a doctor whose logic can only be exercised by reproducing the fault is a doctor nobody
+# has ever seen work.
+# ---------------------------------------------------------------------------------------
+
+<# A stored secret is usable only if it is exactly one line of <hex>:<hex>. That is what
+   fileserver.ps1 parses; anything else makes it exit before it ever listens. #>
+function Test-SecretShape {
+    param([string]$Text)
+    if ($null -eq $Text) { return $false }
+    return ($Text.Trim() -match '^[0-9a-fA-F]+:[0-9a-fA-F]+$')
+}
+
+<# THE ONE. A listener that started BEFORE the secret was last written cannot know the
+   current password: it read the old value out of its environment at spawn and never
+   re-reads the file. Returns $true when that mismatch is present.
+
+   Both timestamps are required. A missing one returns $false -- "cannot tell" must not
+   masquerade as "found the bug", or the doctor starts inventing faults. #>
+function Test-ListenerPredatesSecret {
+    param(
+        [Nullable[datetime]]$ListenerStart,
+        [Nullable[datetime]]$SecretWritten
+    )
+    if ($null -eq $ListenerStart -or $null -eq $SecretWritten) { return $false }
+    return ($ListenerStart -lt $SecretWritten)
+}
+
+<# Windows reserves TCP ranges (Hyper-V, WSL, Docker) that nothing can bind. GobboNet's
+   default 11434 falls inside one on some machines, and the failure is silent: the bind
+   fails, the server picks another port, and nothing is listening where you were told to
+   look. Ranges come from `netsh interface ipv4 show excludedportrange protocol=tcp`. #>
+function Test-PortReserved {
+    param([int]$Port, [array]$Ranges)
+    foreach ($r in $Ranges) {
+        if ($Port -ge $r.Start -and $Port -le $r.End) { return $true }
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------------------------
+function Get-ExcludedPortRanges {
+    $out = @()
+    try {
+        $raw = netsh interface ipv4 show excludedportrange protocol=tcp 2>$null
+        foreach ($line in $raw) {
+            if ($line -match '^\s*(\d+)\s+(\d+)\s*$') {
+                $out += [pscustomobject]@{ Start = [int]$Matches[1]; End = [int]$Matches[2] }
+            }
+        }
+    } catch { }
+    return $out
+}
+
+function Get-PortListener {
+    param([int]$Port)
+    try {
+        $c = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop |
+             Select-Object -First 1
+        if (-not $c) { return $null }
+        $p = Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue
+        return [pscustomobject]@{
+            Pid   = $c.OwningProcess
+            Name  = if ($p) { $p.ProcessName } else { 'unknown' }
+            Start = if ($p) { $p.StartTime } else { $null }
+        }
+    } catch { return $null }
+}
+
+<# WHY $Root IS NOT `param([string]$Root = $PSScriptRoot)`.
+
+   Measured on Windows PowerShell 5.1.26100: with [CmdletBinding()] present, $PSScriptRoot
+   is EMPTY while parameter defaults are bound. Drop [CmdletBinding()] and the same default
+   resolves. So the obvious spelling yields $Root = '' -- every later Join-Path throws a
+   binding error, the port falls back to something the user never chose, and the doctor
+   reports on a folder and a port that are not theirs. On the first real run against a
+   1.6.0 tree that is exactly what happened: it named a FAIL on an unrelated program's
+   listener. A doctor that invents a fault is worse than no doctor.
+
+   Order: -Root  ->  the script's own folder  ->  the current directory. #>
+function Resolve-RootFolder {
+    param([string]$Explicit, [string]$ScriptRoot, [string]$Cwd)
+    foreach ($c in @($Explicit, $ScriptRoot, $Cwd)) {
+        if (-not [string]::IsNullOrWhiteSpace($c)) { return $c.Trim() }
+    }
+    return ''
+}
+
+<# The port has to be resolved the way the LAUNCHER resolves it, in the same order, or the
+   doctor inspects a port nobody is using -- and "nothing is holding port 9066" is a clean
+   bill of health for the exact orphan this tool exists to find.
+
+   launch.bat 1.6.0 (lines 152-206): read .gobbonet-port and strip non-digits; then
+   GEMMA_LISTEN_PORT overrides it if set; then fall back to 9066, which is also what an
+   unusable value falls back to.
+
+   An earlier version of this script scraped launch.bat for the first `set "WEB_PORT=<n>"`.
+   That line IS the 9066 fallback, so it silently ignored the port the installer wrote --
+   checking the default on every machine that had chosen anything else. #>
+function Resolve-WebPort {
+    param([string]$PortFileText, [string]$EnvPort, [int]$Default = 9066)
+    foreach ($candidate in @($EnvPort, $PortFileText)) {
+        $digits = ($candidate -replace '[^0-9]', '')
+        if ($digits -and $digits.Length -le 5) {
+            $n = [int]$digits
+            if ($n -ge 1 -and $n -le 65535) { return $n }
+        }
+    }
+    return $Default
+}
+
+# ---------------------------------------------------------------------------------------
+function Invoke-SelfTest {
+    Write-Host "doctor.ps1 --self-test" -ForegroundColor Cyan
+    $fail = 0
+    function Assert($cond, $label) {
+        if ($cond) { Write-Host "  ok   $label" -ForegroundColor Green }
+        else       { Write-Host "  FAIL $label" -ForegroundColor Red; $script:stFail = $true }
+    }
+    $script:stFail = $false
+
+    # Secret shape
+    Assert (Test-SecretShape 'a1b2:c3d4')            'accepts hex:hex'
+    Assert (Test-SecretShape "a1b2:c3d4`r`n")        'tolerates a trailing newline'
+    Assert (-not (Test-SecretShape ''))              'rejects empty'
+    Assert (-not (Test-SecretShape 'a1b2'))          'rejects a missing half'
+    Assert (-not (Test-SecretShape 'zz:c3d4'))       'rejects non-hex'
+
+    # The orphan check -- BOTH directions, because a rule that always fires is as
+    # useless as one that never does.
+    $secret = Get-Date '2026-08-21 10:00:00'
+    $older  = Get-Date '2026-08-21 09:00:00'
+    $newer  = Get-Date '2026-08-21 10:30:00'
+    Assert (Test-ListenerPredatesSecret $older $secret)          'fires: listener older than the secret'
+    Assert (-not (Test-ListenerPredatesSecret $newer $secret))   'quiet: listener started after'
+    Assert (-not (Test-ListenerPredatesSecret $null $secret))    'quiet: unknown start time is not a finding'
+    Assert (-not (Test-ListenerPredatesSecret $older $null))     'quiet: unknown secret time is not a finding'
+
+    # Reserved ports
+    $ranges = @([pscustomobject]@{ Start = 11412; End = 11511 })
+    Assert (Test-PortReserved 11434 $ranges)         'fires: 11434 inside a reserved range'
+    Assert (-not (Test-PortReserved 8080 $ranges))   'quiet: 8080 outside it'
+    Assert (-not (Test-PortReserved 11434 @()))      'quiet: no ranges means no finding'
+
+    # Root resolution -- both directions, because an empty $Root is how this script
+    # previously fabricated a finding against an unrelated program.
+    Assert ((Resolve-RootFolder 'C:\explicit' 'C:\script' 'C:\cwd') -eq 'C:\explicit')  'root: -Root wins'
+    Assert ((Resolve-RootFolder ''  'C:\script' 'C:\cwd') -eq 'C:\script')               'root: falls back to the script folder'
+    Assert ((Resolve-RootFolder ''  ''          'C:\cwd') -eq 'C:\cwd')                   'root: falls back to the cwd'
+    Assert ((Resolve-RootFolder '   ' ''        'C:\cwd') -eq 'C:\cwd')                   'root: whitespace is not a folder'
+    Assert ((Resolve-RootFolder ''  ''          '')        -eq '')                        'root: nothing resolvable stays empty'
+
+    # Port resolution -- must match launch.bat's order, or every other check inspects the
+    # wrong port and reports a clean bill of health.
+    Assert ((Resolve-WebPort '9066' '7777') -eq 7777)   'port: GEMMA_LISTEN_PORT overrides the file'
+    Assert ((Resolve-WebPort '9066' '')     -eq 9066)   'port: .gobbonet-port is used when no env'
+    Assert ((Resolve-WebPort "8123`r`n" '') -eq 8123)   'port: strips stray characters like the launcher does'
+    Assert ((Resolve-WebPort '' '')         -eq 9066)   'port: falls back to the launcher default'
+    Assert ((Resolve-WebPort 'garbage' '')  -eq 9066)   'port: an unusable file falls back, it does not crash'
+    Assert ((Resolve-WebPort '99999' '')    -eq 9066)   'port: out of range falls back'
+
+    if ($script:stFail) { Write-Host "SELF-TEST FAILED" -ForegroundColor Red; exit 1 }
+    Write-Host "SELF-TEST PASS" -ForegroundColor Green
+    exit 0
+}
+
+if ($SelfTest) { Invoke-SelfTest }
+
+# ---------------------------------------------------------------------------------------
+Write-Host ""
+Write-Host "GobboNet doctor" -ForegroundColor Cyan
+
+$Root = Resolve-RootFolder -Explicit $Root -ScriptRoot $PSScriptRoot -Cwd (Get-Location).Path
+if ([string]::IsNullOrWhiteSpace($Root)) {
+    Write-Host "  could not work out which folder to look at -- pass -Root <path>" -ForegroundColor Yellow
+    exit 2
+}
+Write-Host "  folder: $Root"
+
+if ($Port -le 0) {
+    $portFileText = ''
+    $portFile = Join-Path $Root '.gobbonet-port'
+    if (Test-Path $portFile) {
+        $portFileText = (Get-Content $portFile -Raw -ErrorAction SilentlyContinue)
+    }
+    $Port = Resolve-WebPort -PortFileText $portFileText -EnvPort $env:GEMMA_LISTEN_PORT
+}
+Write-Host "  web port: $Port"
+Write-Host ""
+
+# --- 1. the app is actually here ---------------------------------------------------
+if (Test-Path (Join-Path $Root 'chat.html')) {
+    Say-Ok 'chat.html is present'; $script:Judged++
+} else {
+    Say-Bad "chat.html is NOT in $Root -- run this from the folder you installed into"
+    $script:Judged++
+}
+
+# --- 2. the stored secret --------------------------------------------------------------
+$secretPath = Join-Path $Root '.gobbonet-secret'
+$secretWritten = $null
+if (-not (Test-Path $secretPath)) {
+    Say-Info "no .gobbonet-secret yet -- launch.bat will ask you to set one (that is normal"
+    Say-Info "on a first run). Note the leading DOT; Explorer hides it by default."
+} else {
+    $script:Judged++
+    $secretWritten = (Get-Item $secretPath).LastWriteTime
+    $text = Get-Content $secretPath -Raw -ErrorAction SilentlyContinue
+    if (Test-SecretShape $text) {
+        Say-Ok ".gobbonet-secret parses (written $secretWritten)"
+    } else {
+        Say-Bad ".gobbonet-secret is empty, truncated or not <hex>:<hex>"
+        Say-Info "fix: delete it and run  launch.bat reset-password"
+    }
+}
+
+# --- 3. THE ORPHAN CHECK ---------------------------------------------------------------
+$listener = Get-PortListener -Port $Port
+if (-not $listener) {
+    Say-Ok "nothing is holding port $Port"; $script:Judged++
+} else {
+    $script:Judged++
+    Say-Info "port $Port is held by PID $($listener.Pid) ($($listener.Name)), started $($listener.Start)"
+    if (Test-ListenerPredatesSecret $listener.Start $secretWritten) {
+        Say-Bad "that server STARTED BEFORE your password was set -- it cannot accept it."
+        Say-Info "This is the 'password works in the installer, not in the browser' bug."
+        Say-Info "The password is passed to the server when it starts, so a server already"
+        Say-Info "running has the OLD one and never re-reads the file. Deleting"
+        Say-Info ".gobbonet-secret, reinstalling and turning off antivirus all change nothing."
+        Say-Info ""
+        Say-Info "fix:  Stop-Process -Id $($listener.Pid) -Force"
+        Say-Info "      then run launch.bat again."
+    } elseif ($listener.Name -notmatch 'powershell|pwsh') {
+        Say-Bad "port $Port is owned by $($listener.Name), which is not GobboNet."
+        Say-Info "Choose another port, or stop that program."
+    } else {
+        Say-Ok "the running server is newer than the secret -- consistent"
+    }
+}
+
+# --- 4. reserved port ranges -----------------------------------------------------------
+$ranges = Get-ExcludedPortRanges
+if ($ranges.Count -eq 0) {
+    Say-Dead "could not read Windows' reserved port ranges -- skipping that check"
+} else {
+    $script:Judged++
+    if (Test-PortReserved -Port $Port -Ranges $ranges) {
+        Say-Bad "port $Port is inside a Windows RESERVED range -- nothing can bind it."
+        Say-Info "Windows hands these to Hyper-V/WSL/Docker. The bind fails silently and"
+        Say-Info "the server ends up on some other port, so nothing is listening where you"
+        Say-Info "were told to look. Pick a port outside every reserved range."
+    } else {
+        Say-Ok "port $Port is not in a Windows reserved range"
+    }
+}
+
+Write-Host ""
+if ($script:Judged -eq 0) {
+    Write-Host "could not judge anything -- is this the GobboNet folder?" -ForegroundColor Yellow
+    exit 2
+}
+if ($script:Problems -gt 0) {
+    Write-Host "$($script:Problems) problem(s) found." -ForegroundColor Red
+    exit 1
+}
+Write-Host "All clear ($($script:Judged) checks)." -ForegroundColor Green
+exit 0

--- a/launch.bat
+++ b/launch.bat
@@ -155,16 +155,16 @@ if defined GEMMA_LLM_PORT (
 set "WEB_PORT="
 set "WEB_PORT_SRC="
 if exist "%~dp0.gobbonet-port" (
-    :: Digits only, deliberately.
-    ::
-    :: A plain `for /f` read of this file is fragile in ways that all look
-    :: identical from the outside: a UTF-8 BOM, a UTF-16 file (which some
-    :: installer toolchains produce), a trailing CR, or a stray space each
-    :: yield a value that fails the numeric test below. The old code then
-    :: fell back to 9066 SILENTLY -- so a user who picked 8420 during setup
-    :: got 9066 with no explanation, which reads exactly like "custom ports
-    :: do not work". Strip everything that is not a digit and the file
-    :: parses the same whatever wrote it.
+    rem Digits only, deliberately.
+    rem
+    rem A plain `for /f` read of this file is fragile in ways that all look
+    rem identical from the outside: a UTF-8 BOM, a UTF-16 file (which some
+    rem installer toolchains produce), a trailing CR, or a stray space each
+    rem yield a value that fails the numeric test below. The old code then
+    rem fell back to 9066 SILENTLY -- so a user who picked 8420 during setup
+    rem got 9066 with no explanation, which reads exactly like "custom ports
+    rem do not work". Strip everything that is not a digit and the file
+    rem parses the same whatever wrote it.
     for /f "usebackq delims=" %%P in ("%~dp0.gobbonet-port") do if not defined WEB_PORT_SRC set "WEB_PORT_SRC=%%P"
     if defined HAVE_PS (
         set "GN_RAWPORT=!WEB_PORT_SRC!"
@@ -1130,9 +1130,9 @@ if "!MODEL_CHOICE!"=="4" (
     set "MODEL_DISPLAY=Qwen3.5 9B"
     set "MODEL_FAMILY=qwen"
     set "MODEL_MAX_CTX=131072"
-    :: Qwen3.5 emits reasoning between <think> tags like the rest of the
-    :: Qwen3 line. identify-model.ps1 re-detects this from the GGUF after
-    :: download, so this value only has to be right enough to start with.
+    rem Qwen3.5 emits reasoning between <think> tags like the rest of the
+    rem Qwen3 line. identify-model.ps1 re-detects this from the GGUF after
+    rem download, so this value only has to be right enough to start with.
     set "MODEL_THINK_FMT=deepseek"
     set "CTX_SIZE=32768"
     set "KV_CACHE_TYPE=q8_0"
@@ -1158,19 +1158,19 @@ if "!MODEL_CHOICE!"=="6" (
     set "MODEL_FAMILY=qwen"
     set "MODEL_MAX_CTX=131072"
     set "MODEL_THINK_FMT=deepseek"
-    :: 8192, not the 16384 its predecessor used. The weights are 22.29 GB
-    :: and the gate below asks for 24 GB, so on a card that only just
-    :: qualifies there is under 2 GB left for the KV cache. A context that
-    :: does not fit fails at load with an out-of-memory error rather than
-    :: degrading, so the default errs small; the config panel raises it for
-    :: anyone with headroom.
+    rem 8192, not the 16384 its predecessor used. The weights are 22.29 GB
+    rem and the gate below asks for 24 GB, so on a card that only just
+    rem qualifies there is under 2 GB left for the KV cache. A context that
+    rem does not fit fails at load with an out-of-memory error rather than
+    rem degrading, so the default errs small; the config panel raises it for
+    rem anyone with headroom.
     set "CTX_SIZE=8192"
     set "KV_CACHE_TYPE=q8_0"
     goto :download_model
 )
 if "!MODEL_CHOICE!"=="7" (
-    :: The repo and the filename both carry a deepseek-ai_ prefix. Without
-    :: it the URL 404s, which is what made this slot uninstallable.
+    rem The repo and the filename both carry a deepseek-ai_ prefix. Without
+    rem it the URL 404s, which is what made this slot uninstallable.
     set "DL_REPO=bartowski/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-GGUF"
     set "DL_FILE=deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf"
     set "MODEL_ID=deepseek-r1-8b"
@@ -1184,8 +1184,8 @@ if "!MODEL_CHOICE!"=="7" (
 )
 if "!MODEL_CHOICE!"=="8" (
     set "DL_REPO=ggml-org/gpt-oss-20b-GGUF"
-    :: MXFP4 uppercase. Hugging Face paths are case-sensitive, so the
-    :: lowercase spelling 404s.
+    rem MXFP4 uppercase. Hugging Face paths are case-sensitive, so the
+    rem lowercase spelling 404s.
     set "DL_FILE=gpt-oss-20b-MXFP4.gguf"
     set "MODEL_ID=gpt-oss-20b"
     set "MODEL_DISPLAY=gpt-oss 20B"
@@ -1265,11 +1265,11 @@ if not "!HTTP_OK!"=="1" (
     echo.
     echo  [ERROR] Download failed.
     echo.
-    :: The partial file is kept on a TRANSPORT failure, deliberately, so
-    :: re-running resumes instead of starting a multi-gigabyte transfer
-    :: over. It is still deleted further down when VERIFICATION fails --
-    :: a file that arrived intact but hashes wrong is not something to
-    :: resume, it is something to discard.
+    rem The partial file is kept on a TRANSPORT failure, deliberately, so
+    rem re-running resumes instead of starting a multi-gigabyte transfer
+    rem over. It is still deleted further down when VERIFICATION fails --
+    rem a file that arrived intact but hashes wrong is not something to
+    rem resume, it is something to discard.
     if exist "!GGUF_PART!" (
         for %%A in ("!GGUF_PART!") do set "PART_MB=%%~zA"
         echo         The partial download has been kept. Run launch.bat
@@ -1959,11 +1959,11 @@ if !FRETRIES! gtr 8 (
     echo.
     echo  [*] File server did not come up on :!WEB_PORT!.
     echo.
-    :: fileserver.ps1 has always printed the specific reason -- into a
-    :: window started with -WindowStyle Hidden, so nobody ever read it.
-    :: It now mirrors startup output to fileserver.log. Print that rather
-    :: than guessing; the old guess named one of four possible causes and
-    :: was usually the wrong one.
+    rem fileserver.ps1 has always printed the specific reason -- into a
+    rem window started with -WindowStyle Hidden, so nobody ever read it.
+    rem It now mirrors startup output to fileserver.log. Print that rather
+    rem than guessing; the old guess named one of four possible causes and
+    rem was usually the wrong one.
     if exist "%~dp0fileserver.log" (
         echo      --- fileserver.log -------------------------------------
         type "%~dp0fileserver.log"
@@ -1974,11 +1974,11 @@ if !FRETRIES! gtr 8 (
         echo      script policy, or antivirus quarantine of fileserver.ps1.
     )
     echo.
-    :: The old text said "Desktop chat still works normally." It does not:
-    :: chat.html is SERVED by this file server and all model traffic is
-    :: proxied same-origin through /llm, so when this is down there is no
-    :: chat at all. A leftover from the pre-proxy design, and reporters
-    :: were right to call it out.
+    rem The old text said "Desktop chat still works normally." It does not:
+    rem chat.html is SERVED by this file server and all model traffic is
+    rem proxied same-origin through /llm, so when this is down there is no
+    rem chat at all. A leftover from the pre-proxy design, and reporters
+    rem were right to call it out.
     echo      Desktop chat is ALSO down -- chat.html is served by this
     echo      server, so there is nothing for the browser to reach.
     echo.
@@ -2321,15 +2321,15 @@ if defined HAVE_CURL (
         curl.exe -s -L --fail --retry 3 -o "!_O!" "!_U!"
         if not errorlevel 1 set "_OK=1"
     ) else if /i "!_Q!"=="resume" (
-        :: -C - continues a partial file instead of starting over. Worth
-        :: having for a 22 GB model on a domestic connection, where losing
-        :: 90%% of a download to a dropped Wi-Fi link is a real event.
+        rem -C - continues a partial file instead of starting over. Worth
+        rem having for a 22 GB model on a domestic connection, where losing
+        rem 90%% of a download to a dropped Wi-Fi link is a real event.
         curl.exe -L --fail --retry 3 -C - --progress-bar -o "!_O!" "!_U!"
         if not errorlevel 1 set "_OK=1"
-        :: A server that does not honour range requests fails the resume
-        :: rather than ignoring it, and so does a .part left over from an
-        :: interrupted transfer of a DIFFERENT build of the same filename.
-        :: Both are fixed by starting clean, so try exactly once more.
+        rem A server that does not honour range requests fails the resume
+        rem rather than ignoring it, and so does a .part left over from an
+        rem interrupted transfer of a DIFFERENT build of the same filename.
+        rem Both are fixed by starting clean, so try exactly once more.
         if not "!_OK!"=="1" (
             echo       [..] resume refused -- restarting this download from the beginning...
             del /f /q "!_O!" >nul 2>&1
@@ -2424,8 +2424,8 @@ setlocal EnableDelayedExpansion
 set "_RC=1"
 set "_BODY=%TEMP%\gn_probe_%RANDOM%.txt"
 if defined HAVE_CURL (
-    :: -f makes curl fail on any status >= 400 instead of quietly saving the
-    :: error page and exiting 0.
+    rem -f makes curl fail on any status >= 400 instead of quietly saving the
+    rem error page and exiting 0.
     curl.exe -s -f -o "!_BODY!" "%~1" >nul 2>&1
     if not errorlevel 1 (
         findstr /i "status" "!_BODY!" >nul 2>&1

--- a/launch.bat
+++ b/launch.bat
@@ -239,7 +239,14 @@ if /i "%~1"=="reset-password" (
     echo  [..] Password reset requested -- you'll set a new one now.
 )
 
-if not exist "!SECRET_FILE!" call :setup_password
+:: setlocal inherits the caller's environment, so clear this before deciding it.
+set "SECRET_JUST_SET="
+:: Remember that a NEW salt was written this run, so STEP 5 knows not to adopt a
+:: file server that started before this point -- it is still holding the old one.
+if not exist "!SECRET_FILE!" (
+    call :setup_password
+    set "SECRET_JUST_SET=1"
+)
 if not exist "!SECRET_FILE!" (
     echo  [ERROR] No password was set. Cannot start securely. Exiting.
     pause
@@ -1837,10 +1844,29 @@ if not exist "%~dp0chat.html" (
 :: This lets your phone load chat.html over the network
 :: Lenient on purpose: / answers 401 when not logged in, which is our own
 :: auth layer and therefore proof the file server is up.
+:: Only reuse a running server if it can possibly know the current password.
+::
+:: The secret reaches the server by ENVIRONMENT at spawn time (GEMMA_ACCESS_SECRET,
+:: set further down) and is never re-read. So a server that was already running when
+:: a new salt was written re-hashes with the OLD salt and refuses the password the
+:: user just chose. Adopting it produces "the installer took my password but the
+:: browser will not" -- which survives deleting .gobbonet-secret, reinstalling and
+:: disabling antivirus, because none of those touch a running process. Only a reboot
+:: does, which is why it reads as magic rather than as a stale process.
+::
+:: Falling through lands in the port-holder check below, which already names the PID.
 call :http_probe "http://127.0.0.1:!WEB_PORT!/"
 if not errorlevel 1 (
-    echo  [OK] File server already running on :!WEB_PORT!
-    goto :get_lan_ip
+    if defined SECRET_JUST_SET (
+        echo.
+        echo  [*] Something is already listening on :!WEB_PORT!, and you just set a
+        echo      new password. A server that was already running received the OLD
+        echo      one when it started and never re-reads the file, so it would
+        echo      refuse the password you just chose. Not reusing it.
+    ) else (
+        echo  [OK] File server already running on :!WEB_PORT!
+        goto :get_lan_ip
+    )
 )
 
 :: ---------------------------------------------------------------


### PR DESCRIPTION
# The "password works in the installer, not in the browser" bug — and a doctor

Two separable things. Take either.

1. A guard in `launch.bat` so it won't adopt a file server that can't know the password just set.
2. `doctor.ps1` — standalone local check that names this fault and four others, each with the fix.

No dependencies, nothing networked, no account.

## The report

Discord, 2026-08-21 (Quantum Anomaly): after an uninstall, re-download and reinstall with AV
exceptions, the password set in the installer isn't accepted in the browser. Deleting
`.gobbonet-secret` didn't help. Disabling Defender didn't help.

## Root cause

`launch.bat` probes the web port **before** it spawns the file server (1.6.0, line 1840):

```bat
call :http_probe "http://127.0.0.1:!WEB_PORT!/"
if not errorlevel 1 (
    echo  [OK] File server already running on :!WEB_PORT!
    goto :get_lan_ip
)
```

…and the password reaches the server **by environment, at spawn time** (line 1908):

```bat
set "GEMMA_ACCESS_SECRET=!ACCESS_SECRET!"
```

So an orphaned `fileserver.ps1` from an earlier run gets adopted while still holding the **old
salt**. It never re-reads the file. Every symptom follows:

| Symptom | Why |
|---|---|
| Installer accepts the password | `:setup_password` writes a new `salt:hash` — that part works |
| Browser rejects it | The orphan re-hashes with the **old salt** |
| Deleting `.gobbonet-secret` changes nothing | A running process never re-reads it |
| Reinstalling changes nothing | It doesn't kill a running process |
| Disabling antivirus changes nothing | It was never AV |
| "I rebooted and it fixed itself" | A reboot is the only thing that clears the orphan |

Read rather than guessed: hashing is byte-identical on both sides (UTF-8 over `salt + plaintext`,
SHA-256, lowercase hex), and `fileserver.ps1` hard-exits if the secret is missing or malformed —
so a user who reaches a login form and is refused has a server whose secret parsed fine. The only
remaining difference is *which* salt.

## What 1.6.0 already covers

`TROUBLESHOOTING.md` and the port-holder check handle most of this — the orphan is named, the PID
printed. Not duplicated here.

The gap is narrower: **the reuse branch runs first**, so on the path where a new password was just
set, the launcher never reaches the check that would have named the holder. The one case where
adopting is definitely wrong is the one case the code doesn't ask about.

Separately, a doc line: `TROUBLESHOOTING.md:174` says to delete
`%LOCALAPPDATA%\GobboNet\.gobbonet-secret`. Right for the installer, wrong for the ZIP path the
README also documents, where `launch.bat` reads `%~dp0.gobbonet-secret`. A ZIP user deletes
nothing, sees no change, and concludes deleting the secret doesn't help — the same symptom by a
second route. `doctor.ps1` prints the folder it resolved.

## Change 1 — the guard

Two hunks, mostly comment. `:setup_password` running sets `SECRET_JUST_SET`; the reuse branch
checks it and otherwise behaves exactly as before. Falling through lands in the existing
port-holder check, which already names the PID and offers "Try to start anyway?".

Verified by lifting the patched hunks into a harness and running both branches under `cmd.exe`:
no new password → still adopts; new password → declines and explains. The first version put the
`::` comments *inside* the block, which makes cmd print `The system cannot find the drive
specified.` three times per launch — caught by running it, which is why they now sit above.

If you'd rather have self-healing than a refusal: `fileserver.ps1` could return the **salt** in its
401 (a salt isn't a secret), letting the launcher compare and adopt only on a match. Happy to write
that instead — it's a protocol change and this PR deliberately isn't.

## Change 2 — `doctor.ps1`

```
powershell -NoProfile -ExecutionPolicy Bypass -File doctor.ps1
powershell -NoProfile -ExecutionPolicy Bypass -File doctor.ps1 -SelfTest
```

Exit `0` clear, `1` problem, `2` could not judge — "I couldn't look" is never reported as "nothing
is wrong".

Checks: `chat.html` is where you're running from; `.gobbonet-secret` parses as `<hex>:<hex>` (and
it mentions the leading dot Explorer hides); the listener didn't start before the secret was last
written; the port isn't owned by an unrelated program; the port isn't in a Windows *reserved*
range — that one fails silently, the bind fails and the server lands somewhere else.

Every finding names the fix. For this bug it prints the exact `Stop-Process -Id <pid>`.

### Verified against a real 1.6.0 tree

`-SelfTest` drives the pure decision functions with fixtures, both directions of every rule — a
rule that always fires is as useless as one that never does. 23/23. Mutation-checked: inverting
the port precedence reddens exactly the port arm, inverting folder precedence exactly the two root
arms.

Live, against a clean clone of `main`:

```
[fault present]  [FAIL] that server STARTED BEFORE your password was set   -> exit 1
                        fix:  Stop-Process -Id 48344 -Force
[fault cleared]  All clear (4 checks)                                      -> exit 0
[secret emptied] [FAIL] .gobbonet-secret is empty, truncated or not hex    -> exit 1
[clean checkout] All clear (3 checks)                                      -> exit 0
```

Fires on the fault, clears when fixed, still fires on a different fault, quiet on a healthy install.

### Three bugs that first run found in the doctor itself

Two would have made it actively misleading on your users' machines:

- **`param([string]$Root = $PSScriptRoot)` binds empty when `[CmdletBinding()]` is present**
  (Windows PowerShell 5.1.26100; drop the attribute and it resolves). Every later `Join-Path`
  threw and the folder printed blank.
- **It fell back to port 8080**, found an unrelated program there, and reported a confident
  `[FAIL]`. A doctor that invents a fault is worse than none. Now 9066, your real default.
- **It scraped `launch.bat` for the first `set "WEB_PORT=<n>"`** — which *is* the 9066 fallback
  line, so it ignored `.gobbonet-port` and checked the default on every machine that had chosen
  otherwise. Worst of the three: on a custom port it would have inspected a port nobody was using
  and said "nothing is holding port 9066" — a clean bill of health for the exact fault it exists
  to find. It now resolves the port the way `launch.bat` does, pinned by the self-test.

## On the "5 × system cannot find file" lines

Not explained by the above and not reproduced — flagging rather than folding it in. Worth capturing
which five paths; if they're the model or `llama-server` that's a separate problem.
