### PR TITLE
An opt-in second palette for long sessions: GOBLIN_BIOS: Reduced

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -136,6 +136,15 @@
       </label>
     </div>
 
+    <div class="form-group" style="margin-top:12px;">
+      <label>&#128065; Palette</label>
+      <div class="form-hint" style="margin-top:2px;margin-bottom:10px;">GOBLIN_BIOS is the original. Reduced keeps the same colours and dims the glow &mdash; easier on the eyes over a long session. Nothing leaves your machine either way.</div>
+      <select id="set-theme" onchange="previewTheme(this.value)">
+        <option value="goblin-bios">GOBLIN_BIOS (default)</option>
+        <option value="reduced">GOBLIN_BIOS: Reduced</option>
+      </select>
+    </div>
+
     <div class="form-group" style="margin-top:12px; padding:12px; border:1px solid rgba(255,149,0,0.22); border-radius:var(--radius); background:rgba(255,149,0,0.03);">
       <label>&#9889; Performance &mdash; llama.cpp tuning</label>
       <div class="form-hint" style="margin-top:2px;margin-bottom:12px;">

--- a/contrast.py
+++ b/contrast.py
@@ -1,0 +1,54 @@
+"""Solve GobboNet's Reduced palette. Ratios are COMPUTED, never asserted."""
+def _lin(c):
+    c /= 255.0
+    return c/12.92 if c <= 0.04045 else ((c+0.055)/1.055)**2.4
+def lum(hexs):
+    h = hexs.lstrip('#'); r,g,b = (int(h[i:i+2],16) for i in (0,2,4))
+    return 0.2126*_lin(r)+0.7152*_lin(g)+0.0722*_lin(b)
+def ratio(a,b):
+    la,lb = lum(a),lum(b); hi,lo = max(la,lb),min(la,lb)
+    return (hi+0.05)/(lo+0.05)
+def hex_of(rgb):
+    return '#%02x%02x%02x' % tuple(max(0,min(255,round(c))) for c in rgb)
+def rgb_of(hexs):
+    h = hexs.lstrip('#'); return [int(h[i:i+2],16) for i in (0,2,4)]
+
+def retune(src, bg, target, desat=0.55):
+    """Pull a neon toward its own grey (cuts chroma) then scale to hit `target`.
+    Hue is preserved: this is the same colour, quieter -- not a different palette."""
+    r,g,b = rgb_of(src)
+    grey = 0.2126*r + 0.7152*g + 0.0722*b
+    base = [c + (grey - c)*desat for c in (r,g,b)]
+    lo_s, hi_s, best = 0.0, 2.0, None
+    for _ in range(60):
+        s = (lo_s+hi_s)/2
+        cand = hex_of([c*s for c in base])
+        rr = ratio(cand,bg); best = (cand,rr)
+        if rr > target: hi_s = s
+        else: lo_s = s
+    return best
+
+BG = '#020205'
+SURFACE = '#080814'
+# token, current, role, target ratio on BG
+PLAN = [
+    ('--white',       '#e0f8ff', 'body text',      9.0),
+    ('--cyan-bright', '#00f3ff', 'accent / links', 8.0),
+    ('--cyan-mid',    '#00b8ff', 'accent 2',       6.5),
+    ('--cyan-dim',    '#005a88', 'secondary text', 5.0),
+    ('--green-neon',  '#00ff73', 'success',        7.5),
+    ('--magenta',     '#d900ff', 'highlight',      5.5),
+    ('--red-neon',    '#ff003c', 'error',          5.5),
+]
+print(f"{'token':14} {'now':9} {'ratio':>6}   {'reduced':9} {'ratio':>6}  role")
+out = {}
+for tok, cur, role, target in PLAN:
+    new, rr = retune(cur, BG, target)
+    out[tok] = new
+    print(f"{tok:14} {cur:9} {ratio(cur,BG):6.1f} -> {new:9} {rr:6.1f}  {role}")
+print()
+print("AA 4.5 floor met by all:", all(ratio(v,BG) >= 4.5 for v in out.values()))
+print("none above 15:1 (halation):", all(ratio(v,BG) < 15 for v in out.values()))
+print("also legible on --surface #080814:",
+      all(ratio(v,SURFACE) >= 4.5 for v in out.values()))
+import json; open('reduced.json','w').write(json.dumps(out, indent=2))

--- a/css/01-tokens.css
+++ b/css/01-tokens.css
@@ -134,3 +134,92 @@ body::after {
 ::-webkit-scrollbar-track { background: var(--black); }
 ::-webkit-scrollbar-thumb { background: var(--cyan-dim); border-radius: var(--radius); }
 ::-webkit-scrollbar-thumb:hover { background: var(--cyan-bright); box-shadow: var(--glow-cyan); }
+
+/* ========================================================
+   GOBLIN_BIOS: REDUCED — an opt-in second palette
+   ========================================================
+
+   For people who read GobboNet for hours. Same hues, same identity, same
+   default — pulled out of the range where saturated colour on near-black
+   starts to smear.
+
+   Nothing above this comment changes. GOBLIN_BIOS is still what you get if
+   you never open settings.
+
+   WHY, measured on #020205 with the WCAG 2.1 relative-luminance formula
+   (reproduce with contrast.py in this PR):
+
+     --white        #e0f8ff   18.8:1     body text
+     --cyan-bright  #00f3ff   15.1:1     accent
+     --green-neon   #00ff73   15.3:1     success
+     --cyan-dim     #005a88    2.8:1     secondary text — below the 4.5 AA floor
+
+   The palette is harsh and faint at the same time, which is why turning the
+   monitor down does not help: it lowers the glare and takes the dim text with
+   it. Body copy sits ~19:1 at full chroma, well above the band where sustained
+   reading is comfortable, while the token used for secondary text is the one
+   value that fails AA outright.
+
+   Each value below keeps its hue and moves only chroma and luminance, solved
+   numerically until it lands in band rather than picked by eye. Ratio in the
+   comment is computed, not asserted.
+   ======================================================== */
+
+:root[data-theme="reduced"] {
+  /* grounds are unchanged — the identity lives here */
+  --black:        #020205;
+  --surface:      #080814;
+  --elevated:     #0d0d26;
+  --border:       #1a1a40;
+
+  --white:        #a5adaf;   /*  9.1:1  was 18.8:1  body text            */
+  --cyan-bright:  #56afb3;   /*  8.1:1  was 15.1:1  accent, links        */
+  --cyan-mid:     #4d9ab7;   /*  6.5:1  was  9.2:1  accent 2             */
+  --cyan-dim:     #4284a5;   /*  5.0:1  was  2.8:1  secondary — now AA   */
+  --green-neon:   #52ac7b;   /*  7.4:1  was 15.3:1  success              */
+  --green-dim:    #2f6b4c;   /*  3.3:1  non-text: rails, borders         */
+  --magenta:      #d338ee;   /*  5.5:1  was  5.3:1  highlight            */
+  --magenta-dim:  #6b3080;   /*  non-text                                */
+  --red-neon:     #f53662;   /*  5.5:1  was  5.2:1  error                */
+  --label:        #7f9aa3;   /*  7.0:1  labels                           */
+
+  /* Glow is the other half of the problem and it is a token, so it comes with.
+     A bloom around already-bright text is what makes edges look doubled after
+     an hour. Kept, not deleted — this is still GOBLIN_BIOS, just quieter. */
+  --glow-cyan:    0 0 6px rgba(86, 175, 179, 0.20);
+  --glow-magenta: 0 0 6px rgba(211, 56, 238, 0.18);
+  --glow-red:     0 0 6px rgba(245, 54, 98, 0.22);
+  --glow-text-c:  0 0 4px rgba(86, 175, 179, 0.25);
+  --glow-text-m:  0 0 4px rgba(211, 56, 238, 0.22);
+}
+
+/* The scanline overlay and the flicker keyframe are atmosphere, and atmosphere
+   is the first thing to go for someone who gets migraines or motion sickness.
+   Honour the OS switch regardless of which palette is active — this is not a
+   Reduced-only concern. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+  body::after { display: none; }   /* scanlines */
+}
+
+/* Someone who has asked their OS for MORE contrast is telling you the opposite
+   of what this palette assumes. Give them the full range back, deliberately,
+   rather than leaving Reduced applied to a person who wants the neon. */
+@media (prefers-contrast: more) {
+  :root[data-theme="reduced"] {
+    --white:        #e0f8ff;
+    --cyan-bright:  #00f3ff;
+    --cyan-mid:     #00b8ff;
+    --cyan-dim:     #4fa8cc;   /* not the original #005a88 — that fails AA */
+    --green-neon:   #00ff73;
+    --magenta:      #d900ff;
+    --red-neon:     #ff003c;
+  }
+}

--- a/js/04-state.js
+++ b/js/04-state.js
@@ -144,6 +144,10 @@ const DEFAULT_SETTINGS = {
   smartLimitEnabled: false,   // cap AI reply length (rough token estimate, sentence-end cut)
   smartLimitTokens: 300,      // max estimated tokens per reply when the cap is on
   avatarScale: 1,             // avatar size multiplier (CONFIG slider; 1 = default)
+  // Palette. 'goblin-bios' is the default and always will be; 'reduced'
+  // is opt-in from CONFIG. Unset means goblin-bios, so a save file written
+  // before this existed keeps exactly the look it had.
+  theme: 'goblin-bios',
   // Remote (http/https) images in cards -- avatars, backgrounds, thumbnails.
   // Off by default: a card from an import or a synced peer can point <img src>
   // at any host, and that beacons this machine's IP on render. data:/blob:

--- a/js/15-cards.js
+++ b/js/15-cards.js
@@ -22,6 +22,7 @@ function openSettings() {
   const aScale = state.settings.avatarScale || 1;
   document.getElementById('set-avatar-scale').value = aScale;
   document.getElementById('set-allow-remote-images').checked = !!state.settings.allowRemoteImages;
+  document.getElementById('set-theme').value = state.settings.theme || 'goblin-bios';
   document.getElementById('avatar-scale-val').textContent = Math.round(aScale * 100) + '%';
   document.getElementById('settings-modal').classList.add('open');
 }
@@ -29,6 +30,7 @@ function openSettings() {
 function closeSettings() {
   document.getElementById('settings-modal').classList.remove('open');
   applyAvatarScale(); // revert any unsaved live-preview drag back to the saved value
+  applyTheme();       // and any unsaved palette preview
 }
 
 function saveSettings() {
@@ -39,6 +41,8 @@ function saveSettings() {
   state.settings.cotTimeoutMinutes = parseInt(document.getElementById('set-cot-timeout-minutes').value) || 2;
   state.settings.avatarScale = parseFloat(document.getElementById('set-avatar-scale').value) || 1;
   state.settings.allowRemoteImages = document.getElementById('set-allow-remote-images').checked;
+  state.settings.theme = document.getElementById('set-theme').value || 'goblin-bios';
+  applyTheme();
   saveState();
   closeSettings();
   renderMessages();
@@ -60,6 +64,21 @@ function previewAvatarScale(val) {
 function applyAvatarScale() {
   const scale = (state.settings && state.settings.avatarScale) || 1;
   document.documentElement.style.setProperty('--avatar-scale', scale);
+}
+
+/* Palette -- same shape as the avatar scale above: previewTheme() runs live as
+   the CONFIG selector changes, applyTheme() restores the saved value (on boot,
+   and on Cancel to discard an unsaved preview).
+
+   The whole switch is one attribute on <html>; css/01-tokens.css does the rest
+   under :root[data-theme="reduced"]. No attribute = GOBLIN_BIOS, so a save file
+   written before this existed opens looking exactly as it did. */
+function previewTheme(val) {
+  if (val === 'reduced') document.documentElement.setAttribute('data-theme', 'reduced');
+  else document.documentElement.removeAttribute('data-theme');
+}
+function applyTheme() {
+  previewTheme((state.settings && state.settings.theme) || 'goblin-bios');
 }
 
 /* ================================================================

--- a/js/24-boot.js
+++ b/js/24-boot.js
@@ -45,6 +45,7 @@
   // switched on. Must come after state is restored and before render.
   try { applyCardCode(); } catch (e) { console.error('[card-code] boot:', e); }
   applyAvatarScale(); // restore saved avatar size preference
+  applyTheme();       // restore saved palette
 
   // Load default characters from JSON, then render the landing page.
   // fetch() works when served via launch.bat; fails silently on file:// (no CORS).


### PR DESCRIPTION
# An opt-in second palette: GOBLIN_BIOS: Reduced

From Discord: *"Okay, I'm new to Gobbonet. umm… is there any way to make the interface smoother? Less eye strain inducing?"*

I went looking for what specifically causes that, and it turned out to be measurable rather than a matter of taste. **GOBLIN_BIOS stays the default and is byte-identical** — this adds a second palette behind `[data-theme="reduced"]` and a CONFIG selector.

## What's actually happening

Measured on `#020205` with the WCAG 2.1 relative-luminance formula (`contrast.py` in this PR reproduces every number):

| token | value | ratio | |
|---|---|---|---|
| `--white` | `#e0f8ff` | **18.8:1** | body text |
| `--green-neon` | `#00ff73` | **15.3:1** | |
| `--cyan-bright` | `#00f3ff` | **15.1:1** | accent |
| `--magenta` | `#d900ff` | 5.3:1 | |
| `--red-neon` | `#ff003c` | 5.2:1 | |
| `--cyan-dim` | `#005a88` | **2.8:1** | secondary text — under the 4.5 AA floor |

It's the opposite of a low-contrast problem. Body copy runs at 15–19:1 **at full chroma**, which is where saturated colour on near-black starts to bloom and leave afterimages, while the token used for secondary text is the one value that fails AA outright.

That combination is why the obvious remedies don't work: turning the monitor down reduces the glare *and* takes the already-too-dim text with it.

**The typography is already right** — Atkinson Hyperlegible Mono is the Braille Institute's legibility face, and picking it was a deliberate accessibility decision. Colour just hasn't had the same pass yet. This is meant as finishing that, not second-guessing it.

## What this adds

`css/01-tokens.css` gains a `:root[data-theme="reduced"]` block. Every value keeps its **hue** and moves only chroma and luminance — solved numerically until it lands in band, not picked by eye:

| token | GOBLIN_BIOS | Reduced |
|---|---|---|
| `--white` | `#e0f8ff` 18.8:1 | `#a5adaf` **9.1:1** |
| `--cyan-bright` | `#00f3ff` 15.1:1 | `#56afb3` **8.1:1** |
| `--cyan-mid` | `#00b8ff` 9.2:1 | `#4d9ab7` **6.5:1** |
| `--cyan-dim` | `#005a88` 2.8:1 | `#4284a5` **5.0:1** |
| `--green-neon` | `#00ff73` 15.3:1 | `#52ac7b` **7.4:1** |
| `--magenta` | `#d900ff` 5.3:1 | `#d338ee` **5.5:1** |
| `--red-neon` | `#ff003c` 5.2:1 | `#f53662` **5.5:1** |

Glow comes with it, because `--glow-*` are tokens too and the bloom around bright text is the other half of what makes edges look doubled after an hour. Dimmed, not deleted — it's still GOBLIN_BIOS.

Also two media queries the stylesheet has no answer for today (measured: zero occurrences of either in `css/`):

- `prefers-reduced-motion` — drops the scanline overlay and the flicker keyframe. Applies in **both** palettes; someone who gets migraines isn't only served by the quiet one.
- `prefers-contrast: more` — hands the full range back, because a user asking their OS for *more* contrast is saying the opposite of what Reduced assumes. (`--cyan-dim` stays at an AA-passing value there rather than reverting to `#005a88`.)

## How it's wired

Deliberately the same shape as `avatarScale`, so there's nothing new to learn:

- `theme: 'goblin-bios'` in `DEFAULT_SETTINGS`
- `previewTheme(val)` / `applyTheme()` next to `previewAvatarScale()` / `applyAvatarScale()`
- called from `openSettings` / `saveSettings` / `closeSettings` (Cancel reverts an unsaved preview, same as the avatar slider) and from `24-boot.js`
- one `<select>` in the CONFIG modal

The whole switch is one attribute on `<html>`. **No attribute means GOBLIN_BIOS**, so an existing save file opens looking exactly as it did.

## What I verified

- **Every ratio in this PR is computed, not typed.** A checker parses the CSS comments back out and recomputes them — it caught two of my own claims being wrong (`--green-dim` and `--label`) before this was filed. 9/9 now agree.
- **Cascade resolves**: 19 overrides, every one naming a token the base block defines, no orphans. Base `--white` is still `#e0f8ff`.
- **Diff is additive**: 122 insertions, **0 deletions**, across 5 files.
- **All three JS files still parse**, `set-theme` exists in both the HTML and the JS that reads it, and `previewTheme` is defined where the markup calls it.

## Where I'd want your read

**Scope.** A token swap reaches the 581 `var(--…)` uses. There are 21 opaque hex values sitting outside `01-tokens.css` that won't respond — the remaining 232 hardcoded colours are `rgba()` overlays layered over token-driven backgrounds, so they mostly still read correctly. I've left all 253 alone: hoisting them is a much bigger diff and it's your call whether that's wanted at all. Happy to do it as a follow-up, or not.

**Taste.** I picked target ratios (7–10:1 body, ≥4.5:1 secondary) and solved to them. If Reduced reads too grey to you, the targets are one number each and I'll re-solve to whatever you prefer — the machinery doesn't change.

And if the whole approach is wrong, the measurements at the top are the part worth keeping.
