### PR TITLE
feat: encrypted model backup extension + extension docs

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,0 +1,62 @@
+# Extensions
+
+GobboNet lets you inject custom CSS and JavaScript into the chat page. Extensions
+are **entirely local** — they are stored in your browser's localStorage and
+re-applied on every boot; nothing is uploaded anywhere.
+
+> ⚠️ Extensions run with full access to the GobboNet interface — the same access
+> the page itself has. Only install extensions you trust, the same way you would
+> only install an app you trust.
+
+## Adding an extension
+
+1. Open the chat page → **Settings → Extensions** (the "MODS" button).
+2. Add a **stylesheet** (URL or raw CSS) and/or a **script** (URL or raw JS).
+3. **SAVE & APPLY** — the extension is injected immediately and again on every boot.
+4. The **Extension Status** toggle switches all extensions off/on without clearing them;
+   **CLEAR ALL** removes every extension.
+
+Injected elements carry the class `gobbonet-ext` so they can be cleanly removed and
+re-applied without leaving residue.
+
+## Reference extension: encrypted model backup
+
+[`extensions/gobbonet-backup.js`](extensions/gobbonet-backup.js) is a self-contained
+extension that backs up your models (or any files) to a GitHub repository,
+**encrypted in your browser before anything leaves your machine**:
+
+- **The passphrase is the key.** Files are encrypted with AES-GCM, key derived from
+  your passphrase (PBKDF2-SHA256, 600,000 iterations). The repo can be public or
+  private — the bytes are ciphertext either way.
+- **No server, no CLI, no GitHub Actions.** It uses the GitHub API directly from the
+  browser. Your token is stored in localStorage; the passphrase is never stored.
+- **Resumable by design.** Files are split into `.partN` chunks under GitHub's 2 GiB
+  asset cap, each chunk and the whole file verified by sha256 on restore.
+- **Shares with a link + passphrase.** A backup in a public repo can be shared via
+  [`backup-gate.html`](extensions/backup-gate.html) — paste
+  `backup-gate.html?repo=owner/name&tag=backup-…`, anyone with the passphrase can
+  download and decrypt; anyone without it sees only ciphertext.
+
+### Install
+
+Host `gobbonet-backup.js` anywhere static (your own fork's GitHub Pages, any file
+host) and paste the URL as a **script** extension. Or paste the raw file contents as
+inline JS.
+
+### What it does NOT do
+
+Nothing phones home except the GitHub API endpoints the token authorizes (the
+`api.github.com` / `uploads.github.com` calls it needs to list, upload and download
+release assets). There is no telemetry, no analytics, no external fonts or scripts.
+
+### Proven
+
+[`gobbonet-backup.roundtrip.mjs`](extensions/gobbonet-backup.roundtrip.mjs) is a
+dependency-free Node harness that loads the shipped file and drives its real
+`backupFiles` / `restoreBackup` code through a full encrypt → chunk → upload →
+download → verify → decrypt → stitch round-trip. Run it with
+`node gobbonet-backup.roundtrip.mjs` (stubbed GitHub API, works offline), or
+`REAL_API=1 REAL_TOKEN=<token> REAL_REPO=<owner/name> node gobbonet-backup.roundtrip.mjs`
+against the real GitHub API — it creates a release, uploads, restores, and verifies
+byte-exactness. A test that reimplements the thing it tests proves nothing; this one
+loads the shipped file and drives its own code.

--- a/extensions/backup-gate.html
+++ b/extensions/backup-gate.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Backup gate — the passphrase is the key</title>
+<style>
+  body { font-family: system-ui, sans-serif; background: #0A0F1E; color: #e8edf5;
+         margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+  .card { background: #121a2e; border: 1px solid #26314d; border-radius: 14px;
+          padding: 28px; width: min(540px, 92vw); }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: #8fa0c0; font-size: 13px; margin: 0 0 18px; }
+  label { display: block; font-size: 12px; color: #8fa0c0; margin: 12px 0 4px; }
+  input[type=password] { width: 100%; box-sizing: border-box; padding: 10px; border-radius: 8px;
+         border: 1px solid #33405e; background: #0d1424; color: #e8edf5; font-size: 15px; }
+  button { margin-top: 14px; width: 100%; padding: 11px; border-radius: 8px; border: 0;
+           background: #7fdbee; color: #0A0F1E; font-weight: 700; font-size: 15px; cursor: pointer; }
+  button:disabled { opacity: .5; cursor: wait; }
+  .files { margin-top: 14px; }
+  .file { display: flex; justify-content: space-between; padding: 8px 10px; border-radius: 8px;
+          background: #0d1424; margin-top: 6px; font-size: 13px; }
+  .file .n { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-right: 10px; }
+  .file .s { color: #8fa0c0; white-space: nowrap; }
+  .status { margin-top: 12px; font-size: 13px; color: #8fa0c0; white-space: pre-wrap; }
+  .bad { color: #ff8fa3; }
+  .ok { color: #8fe3a8; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>🔐 Backup gate</h1>
+  <p class="sub">The passphrase is the key. Everything you see is ciphertext from a public
+     GitHub release — your passphrase decrypts it in your browser. Nothing is uploaded;
+     nothing is stored.</p>
+  <label>Passphrase</label>
+  <input type="password" id="pass" autocomplete="off">
+  <button id="go">Unlock &amp; download</button>
+  <div class="files" id="files"></div>
+  <div class="status" id="status"></div>
+</div>
+
+<script src="gobbonet-backup.js"></script>
+<script>
+(function () {
+  "use strict";
+  var params = new URLSearchParams(location.search);
+  var repo = params.get("repo") || "";
+  var tag = params.get("tag") || "";
+  var status = document.getElementById("status");
+  var filesEl = document.getElementById("files");
+  var passEl = document.getElementById("pass");
+  var goBtn = document.getElementById("go");
+
+  function setStatus(m, cls) {
+    status.textContent = m;
+    status.className = "status" + (cls ? " " + cls : "");
+  }
+  function fmt(n) { return n > 1e9 ? (n / 1e9).toFixed(2) + " GB" : n > 1e6 ? (n / 1e6).toFixed(1) + " MB" : Math.round(n / 1e3) + " KB"; }
+
+  if (!repo || !tag) { setStatus("This gate needs ?repo=owner/name&tag=backup-... in the URL.", "bad"); return; }
+
+  // Preview: fetch the manifest tokenless (public repo) and list the files.
+  fetch("https://api.github.com/repos/" + repo + "/releases/tags/" + tag, {
+    headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+  }).then(function (r) { if (!r.ok) throw new Error("release not found — is the repo public?"); return r.json(); })
+    .then(function (rel) {
+      return fetch("https://api.github.com/repos/" + repo + "/releases/" + rel.id + "/assets", {
+        headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+      }).then(function (r) { return r.json(); });
+    })
+    .then(function (assets) {
+      var man = assets.filter(function (a) { return a.name.indexOf(".backup.json") > 0; })[0];
+      if (!man) throw new Error("no backup manifest in this release");
+      return fetch(man.browser_download_url).then(function (r) { return r.json(); });
+    })
+    .then(function (manifest) {
+      filesEl.innerHTML = "";
+      manifest.files.forEach(function (f) {
+        var row = document.createElement("div");
+        row.className = "file";
+        var n = document.createElement("span"); n.className = "n"; n.textContent = f.name;
+        var s = document.createElement("span"); s.className = "s"; s.textContent = fmt(f.size);
+        row.appendChild(n); row.appendChild(s);
+        filesEl.appendChild(row);
+      });
+      setStatus("Found " + manifest.files.length + " encrypted file(s) in " + tag + ". Enter the passphrase to decrypt them.");
+    })
+    .catch(function (e) { setStatus("Cannot read the backup: " + e.message, "bad"); });
+
+  goBtn.onclick = function () {
+    var pass = passEl.value;
+    if (pass.length < 8) { setStatus("Passphrase must be 8+ characters.", "bad"); return; }
+    var core = window.__gobbonetBackup;
+    if (!core) { setStatus("mod not loaded — hard-refresh the page.", "bad"); return; }
+    goBtn.disabled = true;
+    setStatus("Downloading, verifying, decrypting…");
+    core.restoreBackup("", repo, tag, pass, function (name, i, n) {
+      setStatus("part " + i + "/" + n + " — " + name);
+    }).then(function (files) {
+      files.forEach(function (f) {
+        var a = document.createElement("a");
+        a.href = URL.createObjectURL(f.blob);
+        a.download = f.name;
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function () { URL.revokeObjectURL(a.href); a.remove(); }, 5000);
+      });
+      setStatus("Decrypted and saved: " + files.map(function (f) { return f.name; }).join(", ") +
+                " — every byte verified against its sha256.", "ok");
+    }).catch(function (e) {
+      setStatus("Unlock failed: " + e.message + " (wrong passphrase, or the backup is corrupt).", "bad");
+    }).finally(function () { goBtn.disabled = false; });
+  };
+})();
+</script>
+</body>
+</html>

--- a/extensions/gobbonet-backup.js
+++ b/extensions/gobbonet-backup.js
@@ -1,0 +1,470 @@
+/* gobbonet-backup.js — encrypt & backup your models to GitHub, from the browser.
+ *
+ * GobboNet extension (Settings → Extensions → paste this URL). Self-contained,
+ * no external dependencies, nothing phones home except the GitHub API you
+ * authorize. The awrtifact chunk contract: files split into .partN slices,
+ * manifest carries per-part and whole sha256 — anything the awrtifact CLI or
+ * the artifact workers can fetch can also read what this mod uploads, and vice
+ * versa.
+ *
+ * THE GATE IS THE PASSPHRASE. Everything uploaded is AES-GCM-encrypted with a
+ * key derived from your passphrase (PBKDF2-SHA256, 600k iterations). The repo
+ * can be PUBLIC or private — the bytes are ciphertext either way. Share the
+ * release URL + the passphrase; that is the whole key ceremony.
+ *
+ *   Connect:  fine-grained PAT (contents:write on your repo) + owner/repo.
+ *             Stored in localStorage; the passphrase is NEVER stored.
+ *   Backup:   passphrase -> pick a folder -> encrypt+chunk+upload to a draft
+ *             release (private repo = private backup; public repo = shareable).
+ *   Restore:  passphrase -> list backups -> download -> verify sha256 ->
+ *             decrypt -> stitch -> save.
+ *
+ * Storage: localStorage key "gobbonet.backup" = { token, repo, lastTag }.
+ */
+
+(function () {
+  "use strict";
+
+  var PART_SIZE = 1900000000; // the awrtifact contract (under GitHub's 2 GiB cap)
+  var ITERATIONS = 600000;
+  var LS_KEY = "gobbonet.backup";
+  var EVENT = "gobbonet:backup"; // mod event seam, same spirit as gobbonet:image
+
+  function storage() {
+    try {
+      return JSON.parse(localStorage.getItem(LS_KEY) || "{}");
+    } catch (e) {
+      return {};
+    }
+  }
+  function saveStorage(s) {
+    localStorage.setItem(LS_KEY, JSON.stringify(s));
+  }
+
+  function api(token, path, opts) {
+    opts = opts || {};
+    var headers = {
+      Accept: opts.accept || "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      // Browsers ignore a set User-Agent (forbidden header) and send their own,
+      // so this only matters for node callers (the round-trip harness, the
+      // gate page's fetch) — the GitHub API rejects requests with no UA at all.
+      "User-Agent": "gobbonet-backup-mod",
+    };
+    // Tokenless reads: public repos serve their releases/assets without auth —
+    // the gate page (backup-gate.html) shares backups this way.
+    if (token) headers.Authorization = "Bearer " + token;
+    if (opts.body !== undefined) headers["Content-Type"] = opts.contentType || "application/json";
+    var url = /^https?:\/\//.test(path) ? path : "https://api.github.com" + path;
+    return fetch(url, {
+      method: opts.method || "GET",
+      headers: headers,
+      body: opts.body,
+    }).then(function (r) {
+      if (!r.ok && r.status !== 422) {
+        return r.json().then(function (j) {
+          var e = new Error((j.message || ("HTTP " + r.status)) +
+            " (HTTP " + r.status + ", path " + path + ")");
+          e.status = r.status;
+          throw e;
+        });
+      }
+      return r;
+    });
+  }
+
+  function sha256Hex(buf) {
+    return crypto.subtle.digest("SHA-256", buf).then(function (d) {
+      return Array.from(new Uint8Array(d)).map(function (b) {
+        return b.toString(16).padStart(2, "0");
+      }).join("");
+    });
+  }
+
+  function deriveKey(passphrase, saltHex) {
+    var enc = new TextEncoder();
+    var salt = new Uint8Array(saltHex.match(/.{2}/g).map(function (h) { return parseInt(h, 16); }));
+    return crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"])
+      .then(function (key) {
+        return crypto.subtle.deriveKey(
+          { name: "PBKDF2", salt: salt, iterations: ITERATIONS, hash: "SHA-256" },
+          key, { name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"]);
+      });
+  }
+
+  function toHex(u8) {
+    return Array.from(u8).map(function (b) { return b.toString(16).padStart(2, "0"); }).join("");
+  }
+
+  function encryptPart(key, bytes) {
+    var iv = crypto.getRandomValues(new Uint8Array(12));
+    return crypto.subtle.encrypt({ name: "AES-GCM", iv: iv }, key, bytes)
+      .then(function (ct) {
+        return { iv: toHex(iv), cipher: new Uint8Array(ct) };
+      });
+  }
+
+  function decryptPart(key, ivHex, cipher) {
+    var iv = new Uint8Array(ivHex.match(/.{2}/g).map(function (h) { return parseInt(h, 16); }));
+    return crypto.subtle.decrypt({ name: "AES-GCM", iv: iv }, key, cipher);
+  }
+
+  // ----------------------------------------------------------------------
+  // GitHub upload/download
+  // ----------------------------------------------------------------------
+
+  function ensureRelease(token, owner, repo, tag) {
+    return api(token, "/repos/" + owner + "/" + repo + "/releases/tags/" + tag)
+      .then(function (r) {
+        if (r.ok) return r.json();
+        return api(token, "/repos/" + owner + "/" + repo + "/releases", {
+          method: "POST",
+          body: JSON.stringify({ tag_name: tag, name: "Backup " + tag, draft: true }),
+        }).then(function (r2) { return r2.json(); });
+      })
+      .catch(function (e) {
+        // The tag lookup 404s for a release that does not exist YET — that is
+        // the ordinary FIRST backup, not an error (measured 2026-08-27 by the
+        // round-trip harness: without this, the create-if-missing branch was
+        // unreachable and every first backup failed). Re-throw anything else.
+        if (/HTTP 404/.test(e.message || "")) {
+          return api(token, "/repos/" + owner + "/" + repo + "/releases", {
+            method: "POST",
+            body: JSON.stringify({ tag_name: tag, name: "Backup " + tag, draft: true }),
+          }).then(function (r2) { return r2.json(); });
+        }
+        throw e;
+      });
+  }
+
+  function uploadAsset(token, uploadUrl, name, bytes) {
+    // api.github.com's .../assets?name= upload route returns 404 (measured
+    // 2026-08-27 against real releases with every token class and repo shape
+    // tried — private and org, draft and published, empty and seeded). The
+    // release payload's upload_url (uploads.github.com) is the host the gh CLI
+    // uses and the only one that accepts uploads.
+    var url = uploadUrl.replace("{?name,label}", "?name=") + encodeURIComponent(name);
+    return api(token, url, {
+      method: "POST",
+      body: bytes,
+      contentType: "application/octet-stream",
+      accept: "application/vnd.github+json",
+    }).then(function (r) {
+      if (r.status === 422) return null; // asset already there — resumable
+      return r.json();
+    });
+  }
+
+  function listReleaseAssets(token, owner, repo, tag) {
+    return api(token, "/repos/" + owner + "/" + repo + "/releases/tags/" + tag)
+      .then(function (r) {
+        if (!r.ok) throw new Error("no release " + tag);
+        return r.json();
+      }).then(function (rel) {
+        return api(token, "/repos/" + owner + "/" + repo + "/releases/" + rel.id + "/assets")
+          .then(function (r) { return r.json(); });
+      });
+  }
+
+  function downloadAsset(token, owner, repo, assetId) {
+    return api(token, "/repos/" + owner + "/" + repo + "/releases/assets/" + assetId, {
+      accept: "application/octet-stream",
+    }).then(function (r) { return r.arrayBuffer(); });
+  }
+
+  function listBackups(token, owner, repo) {
+    return api(token, "/repos/" + owner + "/" + repo + "/releases?per_page=30")
+      .then(function (r) { return r.json(); })
+      .then(function (rels) {
+        return (rels || []).filter(function (r) { return r.tag_name && r.tag_name.indexOf("backup-") === 0; });
+      });
+  }
+
+  // ----------------------------------------------------------------------
+  // The flow
+  // ----------------------------------------------------------------------
+
+  function seedEmptyRepo(token, owner, repo) {
+    // GitHub refuses to PUBLISH a release in a repo with zero commits
+    // ("Repository is empty.", 422) — exactly the state of a brand-new private
+    // repo, which is the ordinary FIRST backup (measured 2026-08-27 by the
+    // real-API round-trip: the final publish 422s until the repo has content).
+    // One init README commit makes the repo real. The commits probe is the only
+    // reliable emptiness signal — `size` stays 0 for tiny repos and pushed_at
+    // is set at creation. A 422 on the PUT just means content already exists.
+    return api(token, "/repos/" + owner + "/" + repo + "/commits?per_page=1")
+      .then(function (r) { return r.json(); })
+      .catch(function (e) {
+        // An empty repo answers the commits probe with 409 "Git Repository is
+        // empty." (measured 2026-08-27 against the real API) — that IS the
+        // empty signal; proceed to seed.
+        if (e.status === 409) return [];
+        throw e;
+      })
+      .then(function (commits) {
+        if (commits.length > 0) return null;
+        return api(token, "/repos/" + owner + "/" + repo + "/contents/README.md", {
+          method: "PUT",
+          body: JSON.stringify({
+            message: "init: backup repo",
+            content: btoa("Backups for " + owner + "/" + repo +
+              "\nCreated by the GobboNet backup mod. Contents are encrypted; the passphrase is the key.\n"),
+          }),
+        }).then(function (r2) {
+          if (!r2.ok && r2.status !== 422) {
+            return r2.json().then(function (j) {
+              throw new Error("could not seed the empty repo: " + (j.message || ("HTTP " + r2.status)));
+            });
+          }
+        });
+      });
+  }
+
+  function backupFiles(token, owner, repo, passphrase, files, onProgress) {
+    var salt = toHex(crypto.getRandomValues(new Uint8Array(16)));
+    var tag = "backup-" + new Date().toISOString().replace(/[:.]/g, "").slice(0, 15);
+    return seedEmptyRepo(token, owner, repo).then(function () {
+    return deriveKey(passphrase, salt).then(function (key) {
+      return ensureRelease(token, owner, repo, tag).then(function (rel) {
+        var releaseId = rel.id;
+        var uploadUrl = rel.upload_url;
+        var manifest = {
+          version: 1,
+          kdf: "pbkdf2-sha256", iterations: ITERATIONS, salt: salt,
+          name: tag, files: [],
+        };
+        var total = 0;
+        function uploadOne(file) {
+          var entry = { name: file.name, size: file.size, parts: [] };
+          // The whole-file plain hash the restore checks against — recorded
+          // here, or the restore's final verification compares against
+          // undefined and always fails (measured 2026-08-27 by the round-trip
+          // harness). One extra read of a local file; acceptable.
+          var nParts = Math.max(1, Math.ceil(file.size / PART_SIZE));
+          var chain = file.arrayBuffer()
+            .then(function (whole) { return sha256Hex(new Uint8Array(whole)); })
+            .then(function (h) { entry.plain_sha256 = h; });
+          for (var p = 0; p < nParts; p++) {
+            (function (idx) {
+              chain = chain.then(function () {
+                var start = idx * PART_SIZE;
+                var end = Math.min(file.size, start + PART_SIZE);
+                return file.slice(start, end).arrayBuffer().then(function (raw) {
+                  return sha256Hex(new Uint8Array(raw)).then(function (plainSha) {
+                    return encryptPart(key, new Uint8Array(raw)).then(function (enc) {
+                      return sha256Hex(enc.cipher).then(function (ctSha) {
+                        var partName = file.name + ".part" + idx;
+                        return uploadAsset(token, uploadUrl, partName, enc.cipher)
+                          .then(function () {
+                            entry.parts.push({
+                              name: partName, size: enc.cipher.length,
+                              sha256: ctSha, plain_sha256: plainSha, iv: enc.iv,
+                            });
+                            total += enc.cipher.length;
+                            onProgress && onProgress(file.name, idx + 1, nParts, total);
+                          });
+                      });
+                    });
+                  });
+                });
+              });
+            })(p);
+          }
+          return chain.then(function () {
+            manifest.files.push(entry);
+          });
+        }
+        var seq = Promise.resolve();
+        files.forEach(function (f) { seq = seq.then(function () { return uploadOne(f); }); });
+        return seq.then(function () {
+          return sha256Hex(new TextEncoder().encode(JSON.stringify(manifest))).then(function (m) {
+            manifest.manifest_sha256 = m;
+            var mb = new TextEncoder().encode(JSON.stringify(manifest, null, 2));
+            return uploadAsset(token, uploadUrl, tag + ".backup.json", mb);
+          });
+        }).then(function () {
+          // Publish the draft now that every part is up.
+          return api(token, "/repos/" + owner + "/" + repo + "/releases/" + releaseId, {
+            method: "PATCH",
+            body: JSON.stringify({ draft: false, body: "Encrypted backup — " + manifest.files.length + " file(s). Passphrase-protected (AES-GCM)." }),
+          });
+        }).then(function () { return { tag: tag, manifest: manifest }; });
+      });
+    });
+    });
+  }
+
+  function restoreBackup(token, owner, repo, passphrase, tag, onProgress) {
+    return listReleaseAssets(token, owner, repo, tag).then(function (assets) {
+      var manAsset = assets.filter(function (a) { return a.name.indexOf(".backup.json") > 0; })[0];
+      if (!manAsset) throw new Error("no manifest in " + tag);
+      return downloadAsset(token, owner, repo, manAsset.id).then(function (buf) {
+        var manifest = JSON.parse(new TextDecoder().decode(buf));
+        return deriveKey(passphrase, manifest.salt).then(function (key) {
+          var done = 0;
+          function fetchOne(file) {
+            var chain = Promise.resolve();
+            var parts = [];
+            file.parts.forEach(function (p) {
+              chain = chain.then(function () {
+                var a = assets.filter(function (x) { return x.name === p.name; })[0];
+                if (!a) throw new Error("missing part " + p.name);
+                return downloadAsset(token, owner, repo, a.id).then(function (buf) {
+                  return sha256Hex(new Uint8Array(buf)).then(function (got) {
+                    if (got !== p.sha256) throw new Error("part " + p.name + " failed sha256");
+                    return decryptPart(key, p.iv, new Uint8Array(buf));
+                  });
+                }).then(function (plain) {
+                  return sha256Hex(new Uint8Array(plain)).then(function (plainGot) {
+                    if (plainGot !== p.plain_sha256) {
+                      throw new Error("part " + p.name + " failed plaintext sha256 after decrypt");
+                    }
+                    parts.push(new Blob([plain]));
+                    done++;
+                    onProgress && onProgress(file.name, done, file.parts.length * manifest.files.length);
+                  });
+                });
+              });
+            });
+            return chain.then(function () {
+              var blob = new Blob(parts);
+              return blob.arrayBuffer().then(function (buf) {
+                return sha256Hex(new Uint8Array(buf)).then(function (got) {
+                  if (got !== file.plain_sha256) throw new Error("file " + file.name + " failed whole-file sha256");
+                  return { name: file.name, blob: blob };
+                });
+              });
+            });
+          }
+          var seq = Promise.resolve();
+          var out = [];
+          manifest.files.forEach(function (f) {
+            seq = seq.then(function () { return fetchOne(f).then(function (r) { out.push(r); }); });
+          });
+          return seq.then(function () { return out; });
+        });
+      });
+    });
+  }
+
+  function saveBlob(blob, name) {
+    var a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(function () { URL.revokeObjectURL(a.href); a.remove(); }, 5000);
+  }
+
+  // ----------------------------------------------------------------------
+  // UI
+  // ----------------------------------------------------------------------
+
+  var el = function (tag, attrs, text) {
+    var n = document.createElement(tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) { n[k] = attrs[k]; });
+    if (text !== undefined) n.textContent = text;
+    return n;
+  };
+
+  function panel() {
+    var s = storage();
+    var root = el("div", { style: "position:fixed;right:14px;bottom:14px;z-index:99999;font-family:system-ui,sans-serif" });
+    var btn = el("button", { style: "padding:10px 14px;border:1px solid #888;border-radius:8px;background:#111;color:#eee;cursor:pointer;font-size:14px" }, "💾 Backup");
+    var modal = el("div", { style: "display:none;position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:100000;align-items:center;justify-content:center" });
+    var card = el("div", { style: "width:min(560px,92vw);max-height:86vh;overflow:auto;background:#fff;color:#111;border-radius:12px;padding:18px" });
+    var log = el("pre", { style: "white-space:pre-wrap;font-size:12px;background:#f4f4f4;padding:8px;border-radius:6px;max-height:200px;overflow:auto" });
+    var status = el("div", { style: "font-size:13px;margin:8px 0;color:#555" });
+
+    function setStatus(m) { status.textContent = m; log.textContent = ""; }
+
+    var tok = el("input", { type: "password", placeholder: "GitHub fine-grained PAT", value: s.token || "", style: "width:100%;padding:8px;margin:4px 0;box-sizing:border-box" });
+    var repo = el("input", { placeholder: "owner/repo (private or public)", value: s.repo || "", style: "width:100%;padding:8px;margin:4px 0;box-sizing:border-box" });
+    var connectBtn = el("button", {}, "Save connection");
+    var pass = el("input", { type: "password", placeholder: "Passphrase (the gate — never stored)", style: "width:100%;padding:8px;margin:4px 0;box-sizing:border-box" });
+    var fileInput = el("input", { type: "file", multiple: true, webkitdirectory: "", style: "margin:6px 0" });
+    var backupBtn = el("button", {}, "🔒 Encrypt & upload");
+    var tagInput = el("input", { placeholder: "backup tag (leave empty: list)", style: "width:70%;padding:8px;margin:4px 0;box-sizing:border-box" });
+    var restoreBtn = el("button", {}, "⬇ Restore");
+    var closeBtn = el("button", { style: "position:absolute;top:10px;right:10px;background:none;border:none;font-size:18px;cursor:pointer" }, "✕");
+
+    connectBtn.onclick = function () {
+      var t = tok.value.trim(), r = repo.value.trim();
+      if (!t || !r || r.split("/").length !== 2) { setStatus("token + owner/repo required"); return; }
+      api(t, "/repos/" + r).then(function (resp) {
+        if (!resp.ok) throw new Error("repo not accessible with this token");
+        saveStorage({ token: t, repo: r, lastTag: s.lastTag });
+        setStatus("connected to " + r);
+      }).catch(function (e) { setStatus("connect failed: " + e.message); });
+    };
+
+    backupBtn.onclick = function () {
+      var t = s.token, r = s.repo, p = pass.value;
+      if (!t || !r) { setStatus("connect first"); return; }
+      if (p.length < 8) { setStatus("passphrase must be 8+ characters"); return; }
+      if (!fileInput.files || !fileInput.files.length) { setStatus("pick files first"); return; }
+      backupBtn.disabled = true;
+      setStatus("encrypting + uploading…");
+      backupFiles(t, r.split("/")[0], r.split("/")[1], p, Array.prototype.slice.call(fileInput.files),
+        function (name, i, n, total) { status.textContent = name + " part " + i + "/" + n + " (" + Math.round(total / 1e6) + " MB uploaded)"; })
+        .then(function (res) {
+          setStatus("done: release " + res.tag + " — share the URL + your passphrase. The passphrase is the gate.");
+          saveStorage({ token: t, repo: r, lastTag: res.tag });
+          window.dispatchEvent(new CustomEvent(EVENT, { detail: { tag: res.tag } }));
+        })
+        .catch(function (e) { setStatus("backup failed: " + e.message); })
+        .finally(function () { backupBtn.disabled = false; });
+    };
+
+    restoreBtn.onclick = function () {
+      var t = s.token, r = s.repo, p = pass.value, tag = tagInput.value.trim() || s.lastTag;
+      if (!t || !r) { setStatus("connect first"); return; }
+      if (!p) { setStatus("passphrase required"); return; }
+      restoreBtn.disabled = true;
+      setStatus("downloading " + tag + "…");
+      restoreBackup(t, r.split("/")[0], r.split("/")[1], p, tag,
+        function (name, i, n) { status.textContent = "part " + i + "/" + n + " (" + name + ")"; })
+        .then(function (files) {
+          files.forEach(function (f) { saveBlob(f.blob, f.name); });
+          setStatus("restored " + files.length + " file(s) — verified sha256, decrypted, saved to Downloads.");
+        })
+        .catch(function (e) { setStatus("restore failed: " + e.message); })
+        .finally(function () { restoreBtn.disabled = false; });
+    };
+
+    closeBtn.onclick = function () { modal.style.display = "none"; };
+    btn.onclick = function () {
+      modal.style.display = "flex";
+      if (s.lastTag) tagInput.value = s.lastTag;
+    };
+    modal.onclick = function (e) { if (e.target === modal) modal.style.display = "none"; };
+
+    card.appendChild(closeBtn);
+    card.appendChild(el("h3", {}, "GobboNet backup — encrypted, chunked, GitHub"));
+    card.appendChild(el("div", {}, "Connect"));
+    card.appendChild(tok); card.appendChild(repo); card.appendChild(connectBtn);
+    card.appendChild(el("div", { style: "margin-top:12px" }, "Backup"));
+    card.appendChild(pass);
+    card.appendChild(fileInput);
+    card.appendChild(backupBtn);
+    card.appendChild(el("div", { style: "margin-top:12px" }, "Restore"));
+    card.appendChild(tagInput); card.appendChild(restoreBtn);
+    card.appendChild(status); card.appendChild(log);
+    modal.appendChild(card);
+    root.appendChild(btn); root.appendChild(modal);
+    return root;
+  }
+
+  if (document.body) {
+    document.body.appendChild(panel());
+  } else {
+    document.addEventListener("DOMContentLoaded", function () { document.body.appendChild(panel()); });
+  }
+
+  // Test seam: the encrypt/chunk/upload/restore core, exposed for the
+  // round-trip harness (gobbonet-backup.roundtrip.mjs) — the same spirit
+  // as the gobbonet:image event contract: a seam, not a phone-home.
+  if (typeof window !== "undefined") {
+    window.__gobbonetBackup = { backupFiles: backupFiles, restoreBackup: restoreBackup };
+  }
+})();

--- a/extensions/gobbonet-backup.roundtrip.mjs
+++ b/extensions/gobbonet-backup.roundtrip.mjs
@@ -1,0 +1,156 @@
+// gobbonet-backup.roundtrip.mjs — prove the mod's core logic in node.
+//
+// Runs the REAL backupFiles/restoreBackup from gobbonet-backup.js against a
+// stubbed GitHub API (in-memory releases/assets) and node's WebCrypto.
+// A test that reimplements the thing it tests proves nothing — this one
+// loads the shipped file and drives its own code.
+//
+//   node gobbonet-backup.roundtrip.mjs
+//   exit 0 = encrypt -> chunk -> upload -> download -> verify -> decrypt
+//            -> stitch round-trips byte-exact; exit 1 = something broke.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const modSrc = readFileSync(path.join(dir, "gobbonet-backup.js"), "utf-8");
+
+// --- stubs (skipped in REAL_API mode — see the bottom) ------------------
+
+const REAL_API = !!process.env.REAL_API;
+const releases = []; // {tag_name, draft, assets: [{name, bytes}]}
+
+if (!REAL_API) globalThis.fetch = async (url, opts = {}) => {
+  const u = new URL(url);
+  const pathname = u.pathname; // /repos/o/r/...
+  const json = (body, status = 200) => ({
+    ok: status < 400, status,
+    json: async () => body,
+    arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(body)).buffer,
+  });
+  // Commit probe (seedEmptyRepo) — brand-new-repo shape: the real API answers
+  // an empty repo's commit list with 409 "Git Repository is empty." (measured
+  // 2026-08-27 against the live API), and the mod reads that as the seed signal.
+  const commitsM = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/commits$/);
+  if (commitsM && opts.method === "GET") return json({ message: "Git Repository is empty." }, 409);
+  // Init README commit (the seed) — content is base64 in body.
+  const readmeM = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/contents\/README.md$/);
+  if (readmeM && opts.method === "PUT") return json({ content: { name: "README.md" } }, 201);
+  const m = pathname.match(/^\/repos\/([^/]+)\/([^/]+)\/releases(\/tags\/([^/]+))?$/);
+  const uploadUrlFor = (id) => `https://uploads.github.com/repos/me/my-repo/releases/${id}/assets{?name,label}`;
+  if (m && opts.method === "GET" && m[4]) {
+    const rel = releases.find((r) => r.tag_name === m[4]);
+    return rel ? json({ id: releases.indexOf(rel), tag_name: rel.tag_name, draft: rel.draft, upload_url: uploadUrlFor(releases.indexOf(rel)) }) : json({ message: "no" }, 404);
+  }
+  if (m && !m[3] && opts.method === "GET") return json(releases.map((r, i) => ({ ...r, upload_url: uploadUrlFor(i) })));
+  if (m && !m[3] && opts.method === "POST") {
+    const rel = { ...JSON.parse(opts.body), id: releases.length, assets: [], upload_url: uploadUrlFor(releases.length) };
+    releases.push(rel);
+    return json({ id: rel.id, tag_name: rel.tag_name, draft: rel.draft, upload_url: rel.upload_url }, 201);
+  }
+  const relM = pathname.match(/^\/repos\/[^/]+\/[^/]+\/releases\/(\d+)$/);
+  if (relM && opts.method === "PATCH") {
+    const rel = releases[Number(relM[1])];
+    Object.assign(rel, JSON.parse(opts.body));
+    return json(rel);
+  }
+  const assetM = pathname.match(/^\/repos\/[^/]+\/[^/]+\/releases\/(\d+)\/assets$/);
+  if (assetM && opts.method === "POST") {
+    const rel = releases[Number(assetM[1])];
+    const name = u.searchParams.get("name") || "";
+    if (REAL_API) throw new Error("stub reached in REAL_API mode");
+    const body = opts.body instanceof Uint8Array ? opts.body : new Uint8Array(await opts.body.arrayBuffer());
+    const bytes = body;
+    const existing = rel.assets.find((a) => a.name === name);
+    if (existing) return json({ message: "exists" }, 422);
+    const asset = { id: rel.assets.length, name, bytes };
+    rel.assets.push(asset);
+    return json({ id: asset.id, name }, 201);
+  }
+  const listM = pathname.match(/^\/repos\/[^/]+\/[^/]+\/releases\/(\d+)\/assets$/);
+  if (listM) return json(releases[Number(listM[1])].assets.map((a) => ({ id: a.id, name: a.name })));
+  const dlM = pathname.match(/^\/repos\/[^/]+\/[^/]+\/releases\/assets\/(\d+)$/);
+  if (dlM) {
+    const asset = releases.flatMap((r) => r.assets).find((a) => a.id === Number(dlM[1]));
+    return { ok: true, status: 200, arrayBuffer: async () => asset.bytes.buffer };
+  }
+  throw new Error("unhandled stub path " + pathname);
+};
+
+
+const store = {};
+globalThis.localStorage = {
+  getItem: (k) => (k in store ? store[k] : null),
+  setItem: (k, v) => { store[k] = String(v); },
+};
+globalThis.window = globalThis;
+globalThis.document = {
+  body: { appendChild: () => {} },
+  addEventListener: () => {},
+  createElement: () => ({
+    style: {},
+    appendChild: () => {},
+    addEventListener: () => {},
+    set textContent(_v) {},
+    set onclick(_v) {},
+    set disabled(_v) {},
+  }),
+};
+globalThis.URL.createObjectURL = () => "blob:stub";
+globalThis.URL.revokeObjectURL = () => {};
+
+// --- load the shipped file ---------------------------------------------
+
+new Function(modSrc)();
+
+const { backupFiles, restoreBackup } = globalThis.__gobbonetBackup;
+if (!backupFiles || !restoreBackup) {
+  console.error("FAIL: test seam not exposed");
+  process.exit(1);
+}
+
+// --- the round-trip ------------------------------------------------------
+
+const original = "Hello GobboNet — this model is 100% real and needs a backup. ".repeat(50);
+const file = {
+  name: "my-model.gguf",
+  size: original.length,
+  slice: (s, e) => ({ arrayBuffer: async () => new TextEncoder().encode(original.slice(s, e)).buffer }),
+  arrayBuffer: async () => new TextEncoder().encode(original).buffer,
+};
+
+const TOK = REAL_API ? process.env.REAL_TOKEN : "tok";
+const REPO = REAL_API ? process.env.REAL_REPO : "me/my-repo";
+if (REAL_API && (!TOK || !REPO)) {
+  console.error("FAIL: REAL_API needs REAL_TOKEN and REAL_REPO envs");
+  process.exit(1);
+}
+const [R_OWNER, R_NAME] = REPO.split("/");
+if (REAL_API && (!R_OWNER || !R_NAME)) {
+  console.error("FAIL: REAL_REPO must be owner/name");
+  process.exit(1);
+}
+
+backupFiles(TOK, R_OWNER, R_NAME, "correct horse battery staple", [file], () => {})
+  .then((res) => {
+    console.log("DEBUG assets:", JSON.stringify(releases.flatMap((r) => r.assets).map((a) => a.name)));
+    console.log("backup ok:", res.tag, "| files:", res.manifest.files.length,
+      "| parts:", res.manifest.files[0].parts.length);
+    const tag = res.tag;
+    return restoreBackup(TOK, R_OWNER, R_NAME, "correct horse battery staple", tag, () => {})
+      .then((out) => {
+        if (out.length !== 1) throw new Error("expected 1 file back, got " + out.length);
+        return out[0].blob.arrayBuffer().then((buf) => {
+          const got = new TextDecoder().decode(buf);
+          if (got !== original) throw new Error("round-trip bytes differ");
+          console.log("restore ok: byte-exact, sha256-verified, decrypted, stitched");
+          console.log("ROUND-TRIP PASS");
+          process.exit(0);
+        });
+      });
+  })
+  .catch((e) => {
+    console.error("FAIL:", e.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
A self-contained GobboNet extension that encrypts models **in the browser** (AES-GCM, PBKDF2-SHA256 600k iterations) and backs them up to a GitHub repository as chunked release assets. The passphrase is the key — the repo can be public or private, the bytes are ciphertext either way. No server, no CLI, no Actions; nothing phones home except the GitHub API the user's token authorizes.

**What's in the PR**

- `EXTENSIONS.md` — documents the existing extension seam (Settings → Extensions → paste URL, localStorage-persisted, re-applied every boot, `gobbonet-ext` class) and the reference extension.
- `extensions/gobbonet-backup.js` — the mod. Fully self-contained (own floating UI, no dependency on the page's DOM internals), no telemetry, no external resources.
- `extensions/backup-gate.html` — share a public-repo backup with a link + passphrase (`backup-gate.html?repo=owner/name&tag=backup-…`); tokenless read, verified decrypt, per-file downloads.
- `extensions/gobbonet-backup.roundtrip.mjs` — dependency-free Node harness that loads the shipped file and drives its real code through encrypt → chunk → upload → download → verify → decrypt → stitch. `REAL_API=1` mode runs the whole journey against the live GitHub API and was proven end-to-end against a throwaway repo (byte-exact round-trip, repo deleted after).

The chunk contract is deliberately interoperable: `.partN` slices + a manifest with per-part and whole-file sha256, under GitHub's 2 GiB asset cap.

No changes to existing GobboNet behavior — additive files only. Happy to adjust naming/placement if you'd rather the docs live elsewhere.