### PR TITLE
fix(sampler,logging): clamp dry_penalty_last_n >= 0 and add -lv 4 for llama.cpp b10273+ (#33)

### DIFF
--- a/fileserver.ps1
+++ b/fileserver.ps1
@@ -1312,7 +1312,8 @@ function Build-LaunchScript {
         '--n-gpu-layers', "$GpuLayers",
         '--cache-type-k', (ConvertTo-CmdArgSafe $KvCacheType),
         '--cache-type-v', (ConvertTo-CmdArgSafe $KvCacheType),
-        '--parallel',  '1'
+        '--parallel',  '1',
+        '-lv',         '4'
     )
     
     if ($useJinja) { $argList += '--jinja' }

--- a/js/06-state-sync.js
+++ b/js/06-state-sync.js
@@ -531,7 +531,7 @@ function getCardSamplerParams(card) {
     top_k:       card.topK !== undefined ? card.topK : 40,
     top_p:       card.topP !== undefined ? card.topP : 0.95,
     repeat_penalty:  card.repeatPenalty !== undefined ? card.repeatPenalty : 1.1,
-    repeat_last_n:   card.repeatLastN !== undefined ? card.repeatLastN : 64,
+    repeat_last_n:   (card.repeatLastN !== undefined && card.repeatLastN >= 0) ? card.repeatLastN : 64,
     // XTC — off by default
     xtc_probability: card.xtcProbability !== undefined ? card.xtcProbability : 0,
     xtc_threshold:   card.xtcThreshold !== undefined ? card.xtcThreshold : 0.1,
@@ -540,7 +540,7 @@ function getCardSamplerParams(card) {
     dry_multiplier:     card.dryMultiplier !== undefined ? card.dryMultiplier : 0,
     dry_base:           card.dryBase !== undefined ? card.dryBase : 1.75,
     dry_allowed_length: card.dryAllowedLength !== undefined ? card.dryAllowedLength : 2,
-    dry_penalty_last_n: -1
+    dry_penalty_last_n: (card.dryPenaltyLastN !== undefined && card.dryPenaltyLastN >= 0) ? card.dryPenaltyLastN : 0
   };
 }
 

--- a/launch.bat
+++ b/launch.bat
@@ -1590,7 +1590,7 @@ if not "!MODEL_CHAT_TEMPLATE_FILE!"=="" (
 :: new model.
 > "!LAUNCH_SCRIPT!" (
     echo @echo off
-    echo "!SERVER_EXE!" --model "!GGUF_PATH!" --port !SERVER_PORT! --host 127.0.0.1 --ctx-size !CTX_SIZE! --n-gpu-layers !GPU_LAYERS! --cache-type-k !KV_CACHE_TYPE! --cache-type-v !KV_CACHE_TYPE! --parallel 1 !JINJA_FLAG! !CHAT_TEMPLATE_FLAG! --reasoning-format auto ^> "!LOG_FILE!" 2^>^&1
+    echo "!SERVER_EXE!" --model "!GGUF_PATH!" --port !SERVER_PORT! --host 127.0.0.1 --ctx-size !CTX_SIZE! --n-gpu-layers !GPU_LAYERS! --cache-type-k !KV_CACHE_TYPE! --cache-type-v !KV_CACHE_TYPE! --parallel 1 -lv 4 !JINJA_FLAG! !CHAT_TEMPLATE_FLAG! --reasoning-format auto ^> "!LOG_FILE!" 2^>^&1
 )
 
 start /min "llama-server" "!LAUNCH_SCRIPT!"


### PR DESCRIPTION
## Summary

Fixes compatibility issues when running against newer `llama.cpp` releases (`b9829+` and `b10273+`), resolving #33:

1. **DRY Sampler Range Validation (`b10273+`)**:
   - Clamped `dry_penalty_last_n` to `>= 0` (default `0`) in `js/06-state-sync.js`.
   - Upstream b10273+ strictly validates `0 <= value <= 2147483647`; passing `-1` previously triggered an `HTTP 400 Bad Request` during generation.
   - Also guarded `repeat_last_n` to ensure non-negative integers (`>= 0`, default `64`).

2. **Log Verbosity for GPU Detection (`b9829+`)**:
   - Added `-lv 4` flag to `launch.bat` and `fileserver.ps1`.
   - Upstream b9829+ lowered default log verbosity below device offload reporting; `-lv 4` restores offload banner detection in log monitors.

## Verification Proof

Tested and verified directly against `llama-server b10333` on local silicon:

### 1. Reproduction Proof (Pre-patch `HTTP 400 Bad Request` due to `dry_penalty_last_n = -1`)
![Reproduction Proof](https://raw.githubusercontent.com/sam-henry-dev/GobboNet/evidence-vault/evidence/issue33-reproduction-proof.png)

### 2. Resolution Proof (Post-patch smooth generation + GPU offload logging)
![Resolution Proof](https://raw.githubusercontent.com/sam-henry-dev/GobboNet/evidence-vault/evidence/issue33-resolution-proof.png)

Closes #33.