### PR TITLE
Fix unsafe gpt-oss recommendations on 12 GB GPUs

### DIFF
--- a/hardware-probe.ps1
+++ b/hardware-probe.ps1
@@ -122,9 +122,8 @@
 #   }
 #
 # recommended_tier keeps its exact v1 meaning (GPU-driven, and
-# cpu_only still means "no usable GPU offload") so launch.bat's
-# existing markers do not change behaviour. usable_budget_gb is
-# the improved number to switch to when you're ready.
+# cpu_only still means "no usable GPU offload") for compatibility.
+# launch.bat uses usable_budget_gb for model selection and warnings.
 #
 # EXIT CODES:
 #   0 = a usable hardware.json was written (a machine with no GPU

--- a/hw-recommend.ps1
+++ b/hw-recommend.ps1
@@ -25,7 +25,7 @@
 
 $ErrorActionPreference = 'SilentlyContinue'
 
-# Minimum VRAM in GB per catalogue slot.
+# Minimum usable GPU-memory budget in GB per catalogue slot.
 #
 # MUST match the PICK_MIN list in launch.bat. They are separate because one
 # is consumed by batch and one by PowerShell; if they drift, the menu warns
@@ -38,7 +38,10 @@ $min = @{
     5 = 16     # Gemma 4 26B-A4B MoE       ~16 GB
     6 = 24     # Qwen3.6 35B-A3B MoE       ~22 GB  (largest in the catalogue)
     7 = 10     # DeepSeek-R1 8B            ~8.5 GB
-    8 = 12     # gpt-oss 20B               ~12 GB
+    # The file is 11.28 GiB before KV cache, compute buffers, and Windows'
+    # display allocation. A 12 GB card therefore cannot safely run the default
+    # 16K context with every layer forced onto the GPU. Require real headroom.
+    8 = 14     # gpt-oss 20B               11.28 GiB weights + runtime headroom
     9 = 8      # Command R 7B              ~6.6 GB
     10 = 24    # Command R 35B             ~19 GB
 }
@@ -60,6 +63,7 @@ if (-not $h) {
     'REC=0'
     'HW_TIER=unknown'
     'HW_VRAM=0'
+    'HW_BUDGET=0'
     'HW_RAM=0'
     'HW_DISK=0'
     foreach ($i in 1..10) { 'MK_' + $i + '=' }
@@ -70,22 +74,25 @@ $v    = [int]$h.gpu.vram_gb
 $t    = [string]$h.recommended_tier
 $ram  = [int]$h.ram_gb
 $disk = [int]$h.disk.free_gb
+$budget = [int]$h.usable_budget_gb
+if ($budget -le 0 -and $v -gt 0) { $budget = $v }
 
 # Flagship-first: the best model that fits, not the smallest that works.
 # Deliberately stops at slot 5 rather than recommending slot 6 to a 24 GB
 # card -- 22 GB of weights leaves under 2 GB for the KV cache, and a
 # recommendation that fails to load is worse than a conservative one.
 $rec = 0
-if     ($t -eq 'cpu_only') { $rec = 2 }
-elseif ($v -ge 16)         { $rec = 5 }
-elseif ($v -ge 12)         { $rec = 8 }
-elseif ($v -ge 8)          { $rec = 4 }
-elseif ($v -ge 6)          { $rec = 1 }
-else                       { $rec = 2 }
+if     ($t -eq 'cpu_only')   { $rec = 2 }
+elseif ($budget -ge 16)      { $rec = 5 }
+elseif ($budget -ge $min[8]) { $rec = 8 }
+elseif ($budget -ge 8)       { $rec = 4 }
+elseif ($budget -ge 6)       { $rec = 1 }
+else                         { $rec = 2 }
 
 'HW_OK=1'
 'HW_TIER=' + $t
 'HW_VRAM=' + $v
+'HW_BUDGET=' + $budget
 'HW_RAM=' + $ram
 'HW_DISK=' + $disk
 'REC=' + $rec
@@ -98,10 +105,10 @@ foreach ($i in 1..10) {
         # rather than merely slower, so say so instead of showing a VRAM
         # figure that does not apply.
         if ($min[$i] -le 6) { $m = '' } else { $m = '[ likely too slow without a GPU ]' }
-    } elseif ($v -ge $min[$i]) {
+    } elseif ($budget -ge $min[$i]) {
         $m = ''
     } else {
-        $m = '[ needs ~' + $min[$i] + ' GB VRAM - will be slow ]'
+        $m = '[ needs ~' + $min[$i] + ' GB usable GPU memory - will be slow ]'
     }
     'MK_' + $i + '=' + $m
 }

--- a/launch.bat
+++ b/launch.bat
@@ -923,13 +923,13 @@ goto :write_model_json
 :: detected), then parse hardware.json into HW_* vars plus per-model
 :: markers (MK_1..MK_8) and a recommended option number (REC).
 ::
-:: REC = best model that fits detected VRAM (flagship-first):
-::   >=16 GB -> 5 (Gemma 4 26B)   >=12 -> 8 (gpt-oss 20B)
+:: REC = best model that fits the probe's usable memory budget (flagship-first):
+::   >=16 GB -> 5 (Gemma 4 26B)   >=14 -> 8 (gpt-oss 20B)
 ::   >=8  GB -> 4 (Qwen3.5 9B)    >=6  -> 1 (Gemma 4 E4B)
 ::   cpu_only / tiny -> 2 (Llama 3.2 3B)
 :: MK_n is one of:
 ::   "[ RECOMMENDED FOR YOUR PC ]"      (the REC option)
-::   "[ needs ~N GB VRAM - will be slow ]"  (model bigger than VRAM)
+::   "[ needs ~N GB usable GPU memory - will be slow ]"  (model exceeds budget)
 ::   "[ likely too slow without a GPU ]"    (cpu_only + non-tiny model)
 ::   ""                                  (fits fine, no marker)
 ::
@@ -955,6 +955,7 @@ echo.
 set "HW_OK=0"
 set "HW_TIER=unknown"
 set "HW_VRAM=0"
+set "HW_BUDGET=0"
 set "HW_RAM=0"
 set "HW_DISK=0"
 set "REC=0"
@@ -1017,6 +1018,7 @@ echo.
 echo     [8] gpt-oss 20B            MXFP4   ~12 GB   !MK_8!
 echo         OpenAI - open-weights reasoning model
 echo         Uses Harmony channel format for CoT
+echo         Requires headroom beyond model size; 12 GB cards are too tight
 echo.
 echo   -- LARGE (16 GB VRAM and up) --------------------
 echo.
@@ -1050,8 +1052,8 @@ set "MODEL_CHOICE="
 set /p "MODEL_CHOICE=  Your choice [1-11]: "
 if not defined MODEL_CHOICE if not "!REC!"=="0" set "MODEL_CHOICE=!REC!"
 
-:: VRAM safety net -- if the chosen model wants more GPU memory than we
-:: detected, warn and confirm rather than letting a non-technical user
+:: VRAM safety net -- if the chosen model wants more usable GPU memory than
+:: the probe budgeted, warn and confirm rather than letting a non-technical user
 :: download 16 GB of model that will crawl. Skipped when VRAM is unknown
 :: (HW_VRAM=0) so we never block on a failed probe.
 set "PICK_MIN=0"
@@ -1062,18 +1064,22 @@ if "!MODEL_CHOICE!"=="4" set "PICK_MIN=8"
 if "!MODEL_CHOICE!"=="5" set "PICK_MIN=16"
 if "!MODEL_CHOICE!"=="6" set "PICK_MIN=24"
 if "!MODEL_CHOICE!"=="7" set "PICK_MIN=10"
-if "!MODEL_CHOICE!"=="8" set "PICK_MIN=12"
+:: gpt-oss is 11.28 GiB on disk. Its 16K KV cache, compute buffers, and the
+:: display's existing allocation make an exact 12 GB card an unsafe fit.
+if "!MODEL_CHOICE!"=="8" set "PICK_MIN=14"
 :: 9 and 10 had no gate at all, so the VRAM warning never fired for them --
 :: including for slot 10, which is the second-largest model in the list.
 if "!MODEL_CHOICE!"=="9" set "PICK_MIN=8"
 if "!MODEL_CHOICE!"=="10" set "PICK_MIN=24"
 if not defined HW_VRAM set "HW_VRAM=0"
-if !HW_VRAM! gtr 0 if !PICK_MIN! gtr 0 if !HW_VRAM! lss !PICK_MIN! (
+if not defined HW_BUDGET set "HW_BUDGET=!HW_VRAM!"
+if "!HW_BUDGET!"=="0" if !HW_VRAM! gtr 0 set "HW_BUDGET=!HW_VRAM!"
+if !HW_VRAM! gtr 0 if !HW_BUDGET! gtr 0 if !PICK_MIN! gtr 0 if !HW_BUDGET! lss !PICK_MIN! (
     echo.
-    echo  [*] Heads up: this model wants about !PICK_MIN! GB of GPU
-    echo       memory, but only !HW_VRAM! GB was detected. It can still
-    echo       run by spilling into system RAM, but expect it to be
-    echo       noticeably slower than a model that fits your GPU.
+    echo  [*] Heads up: this model needs about !PICK_MIN! GB of usable GPU
+    echo       memory, but this PC's safe budget is !HW_BUDGET! GB
+    echo       ^(!HW_VRAM! GB VRAM detected^). It can still run by spilling
+    echo       into system RAM, but expect it to be noticeably slower.
     echo.
     call :prompt_yn "  Download it anyway?" GO_BIG
     if /i "!GO_BIG!"=="N" goto :show_catalog


### PR DESCRIPTION
  Fixes ElodineOfficial/GobboNet#23

  Prevents GobboNet from recommending gpt-oss 20B on 12 GB GPUs,
  where model weights, KV cache, runtime buffers, and Windows display
  usage exceed available VRAM and can cause first-message crashes.

  - Uses `usable_budget_gb` instead of nominal VRAM.
  - Requires 14 GB usable GPU memory for gpt-oss 20B.
  - Recommends Qwen3.5 9B on 12 GB systems.
  - Warns before manually downloading gpt-oss on undersized GPUs.
  - Preserves compatibility with older hardware-probe data.